### PR TITLE
Show more episode info in the page title for a series

### DIFF
--- a/src/components/video/DecoratedVideoPlayer.tsx
+++ b/src/components/video/DecoratedVideoPlayer.tsx
@@ -14,6 +14,7 @@ import { ShowTitleControl } from "./controls/ShowTitleControl";
 import { SkipTime } from "./controls/SkipTime";
 import { TimeControl } from "./controls/TimeControl";
 import { VolumeControl } from "./controls/VolumeControl";
+import { PageTitleControl } from "./controls/PageTitleControl";
 import { VideoPlayerError } from "./parts/VideoPlayerError";
 import { VideoPlayerHeader } from "./parts/VideoPlayerHeader";
 import { useVideoPlayerState } from "./VideoContext";
@@ -67,6 +68,7 @@ export function DecoratedVideoPlayer(
 
   return (
     <VideoPlayer autoPlay={props.autoPlay}>
+      <PageTitleControl media={props.media} />
       <VideoPlayerError media={props.media} onGoBack={props.onGoBack}>
         <BackdropControl onBackdropChange={onBackdropChange}>
           <div className="absolute inset-0 flex items-center justify-center">

--- a/src/components/video/controls/PageTitleControl.tsx
+++ b/src/components/video/controls/PageTitleControl.tsx
@@ -7,12 +7,12 @@ interface PageTitleControlProps {
 }
 
 export function PageTitleControl(props: PageTitleControlProps) {
-  const { isSeries, episodeIdentifier } = useCurrentSeriesEpisodeInfo();
+  const { isSeries, humanizedEpisodeId } = useCurrentSeriesEpisodeInfo();
 
   if (!props.media) return null;
 
   const title = isSeries
-    ? `${props.media.title} - ${episodeIdentifier}`
+    ? `${props.media.title} - ${humanizedEpisodeId}`
     : props.media.title;
 
   return (

--- a/src/components/video/controls/PageTitleControl.tsx
+++ b/src/components/video/controls/PageTitleControl.tsx
@@ -1,0 +1,23 @@
+import { MWMediaMeta } from "@/backend/metadata/types";
+import { Helmet } from "react-helmet";
+import { useCurrentSeriesEpisodeInfo } from "../hooks/useCurrentSeriesEpisodeInfo";
+
+interface PageTitleControlProps {
+  media?: MWMediaMeta;
+}
+
+export function PageTitleControl(props: PageTitleControlProps) {
+  const { isSeries, episodeIdentifier } = useCurrentSeriesEpisodeInfo();
+
+  if (!props.media) return null;
+
+  const title = isSeries
+    ? `${props.media.title} - ${episodeIdentifier}`
+    : props.media.title;
+
+  return (
+    <Helmet>
+      <title>{title}</title>
+    </Helmet>
+  );
+}

--- a/src/components/video/controls/ShowTitleControl.tsx
+++ b/src/components/video/controls/ShowTitleControl.tsx
@@ -1,14 +1,14 @@
 import { useCurrentSeriesEpisodeInfo } from "../hooks/useCurrentSeriesEpisodeInfo";
 
 export function ShowTitleControl() {
-  const { isSeries, currentEpisodeInfo, episodeIdentifier } =
+  const { isSeries, currentEpisodeInfo, humanizedEpisodeId } =
     useCurrentSeriesEpisodeInfo();
 
   if (!isSeries) return null;
 
   return (
     <p className="ml-8 select-none space-x-2 text-white">
-      <span>{episodeIdentifier}</span>
+      <span>{humanizedEpisodeId}</span>
       <span className="opacity-50">{currentEpisodeInfo?.title}</span>
     </p>
   );

--- a/src/components/video/controls/ShowTitleControl.tsx
+++ b/src/components/video/controls/ShowTitleControl.tsx
@@ -1,29 +1,14 @@
-import { useMemo } from "react";
-import { useVideoPlayerState } from "../VideoContext";
+import { useCurrentSeriesEpisodeInfo } from "../hooks/useCurrentSeriesEpisodeInfo";
 
 export function ShowTitleControl() {
-  const { videoState } = useVideoPlayerState();
+  const { isSeries, currentEpisodeInfo, episodeIdentifier } =
+    useCurrentSeriesEpisodeInfo();
 
-  const { current, seasons } = videoState.seasonData;
-
-  const currentSeasonInfo = useMemo(() => {
-    return seasons?.find((season) => season.id === current?.seasonId);
-  }, [seasons, current]);
-
-  const currentEpisodeInfo = useMemo(() => {
-    return currentSeasonInfo?.episodes?.find(
-      (episode) => episode.id === current?.episodeId
-    );
-  }, [currentSeasonInfo, current]);
-
-  if (!videoState.seasonData.isSeries) return null;
-  if (!videoState.seasonData.current) return null;
-
-  const selectedText = `S${currentSeasonInfo?.number} E${currentEpisodeInfo?.number}`;
+  if (!isSeries) return null;
 
   return (
     <p className="ml-8 select-none space-x-2 text-white">
-      <span>{selectedText}</span>
+      <span>{episodeIdentifier}</span>
       <span className="opacity-50">{currentEpisodeInfo?.title}</span>
     </p>
   );

--- a/src/components/video/hooks/useCurrentSeriesEpisodeInfo.ts
+++ b/src/components/video/hooks/useCurrentSeriesEpisodeInfo.ts
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import { useVideoPlayerState } from "../VideoContext";
+
+export function useCurrentSeriesEpisodeInfo() {
+  const { videoState } = useVideoPlayerState();
+
+  const { current, seasons } = videoState.seasonData;
+
+  const currentSeasonInfo = useMemo(() => {
+    return seasons?.find((season) => season.id === current?.seasonId);
+  }, [seasons, current]);
+
+  const currentEpisodeInfo = useMemo(() => {
+    return currentSeasonInfo?.episodes?.find(
+      (episode) => episode.id === current?.episodeId
+    );
+  }, [currentSeasonInfo, current]);
+
+  const isSeries = Boolean(
+    videoState.seasonData.isSeries && videoState.seasonData.current
+  );
+
+  if (!isSeries) return { isSeries: false };
+
+  const episodeIdentifier = `S${currentSeasonInfo?.number} E${currentEpisodeInfo?.number}`;
+
+  return {
+    isSeries: true,
+    episodeIdentifier,
+    currentSeasonInfo,
+    currentEpisodeInfo,
+  };
+}

--- a/src/components/video/hooks/useCurrentSeriesEpisodeInfo.ts
+++ b/src/components/video/hooks/useCurrentSeriesEpisodeInfo.ts
@@ -22,11 +22,11 @@ export function useCurrentSeriesEpisodeInfo() {
 
   if (!isSeries) return { isSeries: false };
 
-  const episodeIdentifier = `S${currentSeasonInfo?.number} E${currentEpisodeInfo?.number}`;
+  const humanizedEpisodeId = `S${currentSeasonInfo?.number} E${currentEpisodeInfo?.number}`;
 
   return {
     isSeries: true,
-    episodeIdentifier,
+    humanizedEpisodeId,
     currentSeasonInfo,
     currentEpisodeInfo,
   };

--- a/src/views/media/MediaView.tsx
+++ b/src/views/media/MediaView.tsx
@@ -111,7 +111,6 @@ export function MediaViewPlayer(props: MediaViewPlayerProps) {
   return (
     <div className="fixed top-0 left-0 h-[100dvh] w-screen">
       <Helmet>
-        <title>{props.meta.meta.title}</title>
         <html data-full="true" />
       </Helmet>
       <DecoratedVideoPlayer media={props.meta.meta} onGoBack={goBack} autoPlay>


### PR DESCRIPTION
Was playing with the v3 of the site and thought this might be a good addition, as I generally look at the title for this info

Changes:
- Extracted the logic to generate the S`X`E`Y` from `ShowTitleControl` to a reusable hook
- Created a control to update the title

Just a few questions/points of discussion before a possible merge:
* Better name for `episodeIdentifier`?
* Better way to block usage of data in `useCurrentSeriesEpisodeInfo` to only when it is a series? I currently attempted a way similar to the union pattern I saw used
* Should the data from the new hook be moved into the player state or another store?