### PR TITLE
fix(meta): fallback to no "_latest"

### DIFF
--- a/src/backend/metadata/getmeta.ts
+++ b/src/backend/metadata/getmeta.ts
@@ -56,19 +56,15 @@ export async function getMetaFromId(
 
   let imdbId = data.external_ids.find(
     (v) => v.provider === "imdb_latest"
-  )?.external_id
+  )?.external_id;
   if (!imdbId)
-    imdbId = data.external_ids.find(
-      (v) => v.provider === "imdb"
-    )?.external_id;
+    imdbId = data.external_ids.find((v) => v.provider === "imdb")?.external_id;
 
   let tmdbId = data.external_ids.find(
     (v) => v.provider === "tmdb_latest"
-  )?.external_id
+  )?.external_id;
   if (!tmdbId)
-  tmdbId = data.external_ids.find(
-      (v) => v.provider === "tmdb"
-    )?.external_id;
+    tmdbId = data.external_ids.find((v) => v.provider === "tmdb")?.external_id;
 
   if (!imdbId || !tmdbId) throw new Error("not enough info");
 

--- a/src/backend/metadata/getmeta.ts
+++ b/src/backend/metadata/getmeta.ts
@@ -56,9 +56,13 @@ export async function getMetaFromId(
 
   const imdbId = data.external_ids.find(
     (v) => v.provider === "imdb_latest"
+  )?.external_id ?? data.external_ids.find(
+    (v) => v.provider === "imdb"
   )?.external_id;
   const tmdbId = data.external_ids.find(
     (v) => v.provider === "tmdb_latest"
+  )?.external_id ?? data.external_ids.find(
+    (v) => v.provider === "tmdb"
   )?.external_id;
 
   if (!imdbId || !tmdbId) throw new Error("not enough info");

--- a/src/backend/metadata/getmeta.ts
+++ b/src/backend/metadata/getmeta.ts
@@ -54,16 +54,21 @@ export async function getMetaFromId(
     throw err;
   }
 
-  const imdbId = data.external_ids.find(
+  let imdbId = data.external_ids.find(
     (v) => v.provider === "imdb_latest"
-  )?.external_id ?? data.external_ids.find(
-    (v) => v.provider === "imdb"
-  )?.external_id;
-  const tmdbId = data.external_ids.find(
+  )?.external_id
+  if (!imdbId)
+    imdbId = data.external_ids.find(
+      (v) => v.provider === "imdb"
+    )?.external_id;
+
+  let tmdbId = data.external_ids.find(
     (v) => v.provider === "tmdb_latest"
-  )?.external_id ?? data.external_ids.find(
-    (v) => v.provider === "tmdb"
-  )?.external_id;
+  )?.external_id
+  if (!tmdbId)
+  tmdbId = data.external_ids.find(
+      (v) => v.provider === "tmdb"
+    )?.external_id;
 
   if (!imdbId || !tmdbId) throw new Error("not enough info");
 


### PR DESCRIPTION
fixes the "Whoops, it broke!" error on the [Sweet Home (2020)](https://movie-web.app/media/JW-show-223530) series.