### PR TITLE
Add security headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: origin-when-cross-origin


### PR DESCRIPTION
in order:
 - disallow iframing of the website
 - enable XSS protection on legacy browsers (modern ones dont support it)
 - disallow browsers from guessing mime types but use the content-type header instead
 - do no send referrer info when navigating away from the site
 
 resolves #183 