### PR TITLE
Remove isFocused verification for Keyboard shortcuts

### DIFF
--- a/src/video/components/actions/KeyboardShortcutsAction.tsx
+++ b/src/video/components/actions/KeyboardShortcutsAction.tsx
@@ -27,8 +27,6 @@ export function KeyboardShortcutsAction() {
 
     let isRolling = false;
     const onKeyDown = (evt: KeyboardEvent) => {
-      if (!videoInterface.isFocused) return;
-
       switch (evt.key.toLowerCase()) {
         // Toggle fullscreen
         case "f":


### PR DESCRIPTION
I removed the isFocused verification when using a keyboard shortcut because it didn't allow to do a keyboard shortcut when the video is not focused.