### PR TITLE
Add serverf4 provider

### DIFF
--- a/src/backend/helpers/fetch.ts
+++ b/src/backend/helpers/fetch.ts
@@ -29,7 +29,11 @@ export function mwFetch<T>(url: string, ops: P<T>[1] = {}): R<T> {
   return baseFetch<T>(url, ops);
 }
 
-export function proxiedFetch<T>(url: string, ops: P<T>[1] = {}): R<T> {
+export function proxiedFetch<T>(
+  url: string,
+  ops: P<T>[1] = {},
+  raw = false
+): R<T> {
   let combinedUrl = ops?.baseURL ?? "";
   if (
     combinedUrl.length > 0 &&
@@ -49,6 +53,16 @@ export function proxiedFetch<T>(url: string, ops: P<T>[1] = {}): R<T> {
   Object.entries(ops?.params ?? {}).forEach(([k, v]) => {
     parsedUrl.searchParams.set(k, v);
   });
+
+  if (raw) {
+    return baseFetch.raw<T>(getProxyUrl(), {
+      ...ops,
+      baseURL: undefined,
+      params: {
+        destination: parsedUrl.toString(),
+      },
+    });
+  }
 
   return baseFetch<T>(getProxyUrl(), {
     ...ops,

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -5,6 +5,7 @@ import "./providers/gdriveplayer";
 import "./providers/flixhq";
 import "./providers/superstream";
 import "./providers/netfilm";
+import "./providers/serverf4";
 import "./providers/m4ufree";
 
 // embeds

--- a/src/backend/providers/serverf4.ts
+++ b/src/backend/providers/serverf4.ts
@@ -1,0 +1,77 @@
+import { registerProvider } from "@/backend/helpers/register";
+import { MWMediaType } from "@/backend/metadata/types";
+import { MWStreamQuality } from "@/backend/helpers/streams";
+import { proxiedFetch } from "../helpers/fetch";
+
+const BASE_URL = "https://api.123movie.cc";
+const SERVER = "serverf4";
+
+registerProvider({
+  id: "serverf4",
+  displayName: "serverf4",
+  disabled: false,
+  rank: 50,
+  type: [MWMediaType.MOVIE],
+
+  async scrape({ progress, media: { imdbId } }) {
+    progress(10);
+
+    const document = await proxiedFetch<any>(
+      `/imdb.php/?${new URLSearchParams({
+        imdb: imdbId,
+        server: SERVER,
+      })}`,
+      {
+        baseURL: BASE_URL,
+        headers: {
+          "X-Referer": BASE_URL,
+        },
+      }
+    );
+
+    const HTMLdoc = new DOMParser().parseFromString(document, "text/html");
+
+    const iframeSrc = HTMLdoc.querySelector("iframe")?.src;
+
+    if (!iframeSrc) {
+      throw new Error("No iframe found");
+    }
+
+    const iframeDocument = await proxiedFetch<any>(
+      iframeSrc,
+      {
+        headers: {
+          "X-Referer": BASE_URL,
+        },
+      },
+      true
+    );
+
+    // The X-Destination does not exist in the response and needs to be added to the proxy
+    const id = iframeDocument.headers.get("X-Destination").split("/v/")[1];
+
+    const videoInfo = await proxiedFetch<any>(
+      `https://serverf4.org/api/source/${id}`,
+      {
+        method: "POST",
+      }
+    );
+
+    const source = videoInfo.data[videoInfo.data.length - 1];
+
+    let quality;
+    if (source.type === "720p") quality = MWStreamQuality.Q720P;
+    else if (source.type === "480p") quality = MWStreamQuality.Q480P;
+    else quality = MWStreamQuality.QUNKNOWN;
+
+    return {
+      stream: {
+        streamUrl: source.file,
+        type: source.type,
+        quality,
+        captions: videoInfo.captions,
+      },
+      embeds: [],
+    };
+  },
+});

--- a/src/backend/providers/serverf4.ts
+++ b/src/backend/providers/serverf4.ts
@@ -33,22 +33,21 @@ registerProvider({
 
     const iframeSrc = HTMLdoc.querySelector("iframe")?.src;
 
-    if (!iframeSrc) {
-      throw new Error("No iframe found");
-    }
+    if (!iframeSrc) throw new Error("No iframe found");
 
     const iframeDocument = await proxiedFetch<any>(
       iframeSrc,
       {
         headers: {
           "X-Referer": BASE_URL,
+          "X-Disable-Redirect-Following": "true",
         },
       },
       true
     );
 
     // The X-Destination does not exist in the response and needs to be added to the proxy
-    const id = iframeDocument.headers.get("X-Destination").split("/v/")[1];
+    const id = iframeDocument.headers.get("location").split("/v/")[1];
 
     const videoInfo = await proxiedFetch<any>(
       `https://serverf4.org/api/source/${id}`,
@@ -58,6 +57,8 @@ registerProvider({
     );
 
     const source = videoInfo.data[videoInfo.data.length - 1];
+
+    if (!source) throw new Error("No source found");
 
     let quality;
     if (source.type === "720p") quality = MWStreamQuality.Q720P;
@@ -74,4 +75,6 @@ registerProvider({
       embeds: [],
     };
   },
+});
+
 });


### PR DESCRIPTION
**This should be working (tested with no-CORS extension) but there is one issue:**
- The provider needs to make a request to an URL, not to read the contents, but to see what URL it finally redirects to. 
- Usually when requesting a URL with redirects, the fetch api would return an object that contains the final URL including redirects. 
- But when using a CORS proxy, redirects are handled by the proxy and the final URL is the same as the URL requested

**Possible solutions**
- Don't handle redirects with the proxy and make the client handle them
- Add a `X-Final-Destination` header to the response