### PR TITLE
fix: move meta id check to providers

### DIFF
--- a/src/__tests__/providers/testdata.ts
+++ b/src/__tests__/providers/testdata.ts
@@ -4,7 +4,6 @@ import { MWMediaType } from "@/backend/metadata/types";
 export const testData: DetailedMeta[] = [
   {
     imdbId: "tt10954562",
-    tmdbId: "572716",
     meta: {
       id: "439596",
       title: "Hamilton",
@@ -15,7 +14,6 @@ export const testData: DetailedMeta[] = [
   },
   {
     imdbId: "tt11126994",
-    tmdbId: "94605",
     meta: {
       id: "222333",
       title: "Arcane",

--- a/src/backend/metadata/getmeta.ts
+++ b/src/backend/metadata/getmeta.ts
@@ -29,8 +29,7 @@ interface JWDetailedMeta extends JWMediaResult {
 
 export interface DetailedMeta {
   meta: MWMediaMeta;
-  tmdbId: string;
-  imdbId: string;
+  imdbId?: string;
 }
 
 export async function getMetaFromId(
@@ -61,14 +60,6 @@ export async function getMetaFromId(
   if (!imdbId)
     imdbId = data.external_ids.find((v) => v.provider === "imdb")?.external_id;
 
-  let tmdbId = data.external_ids.find(
-    (v) => v.provider === "tmdb_latest"
-  )?.external_id;
-  if (!tmdbId)
-    tmdbId = data.external_ids.find((v) => v.provider === "tmdb")?.external_id;
-
-  if (!imdbId || !tmdbId) throw new Error("not enough info");
-
   let seasonData: JWSeasonMetaResult | undefined;
   if (data.object_type === "show") {
     const seasonToScrape = seasonId ?? data.seasons?.[0].id.toString() ?? "";
@@ -81,6 +72,5 @@ export async function getMetaFromId(
   return {
     meta: formatJWMeta(data, seasonData),
     imdbId,
-    tmdbId,
   };
 }

--- a/src/backend/providers/gdriveplayer.ts
+++ b/src/backend/providers/gdriveplayer.ts
@@ -41,6 +41,7 @@ registerProvider({
   type: [MWMediaType.MOVIE],
 
   async scrape({ progress, media: { imdbId } }) {
+    if (!imdbId) throw new Error("not enough info");
     progress(10);
     const streamRes = await proxiedFetch<string>(
       "https://database.gdriveplayer.us/player.php",

--- a/src/backend/providers/hdwatched.ts
+++ b/src/backend/providers/hdwatched.ts
@@ -123,6 +123,7 @@ registerProvider({
   type: [MWMediaType.MOVIE, MWMediaType.SERIES],
   async scrape(options) {
     const { media, progress } = options;
+    if (!media.imdbId) throw new Error("not enough info");
     if (!this.type.includes(media.meta.type)) {
       throw new Error("Unsupported type");
     }

--- a/src/views/developer/VideoTesterView.tsx
+++ b/src/views/developer/VideoTesterView.tsx
@@ -24,7 +24,6 @@ const testData: VideoData = {
 };
 const testMeta: DetailedMeta = {
   imdbId: "",
-  tmdbId: "",
   meta: {
     id: "hello-world",
     title: "Big Buck Bunny",


### PR DESCRIPTION
This PR removes the tmdbId from DetailedMeta and moves the imdbId check to the providers that require them.

*This PR has been tested and no errors have been found. Typings have been properly changed.*