### PR TITLE
fix(metadata): hotfix lonely poster path

### DIFF
--- a/src/backend/metadata/getmeta.ts
+++ b/src/backend/metadata/getmeta.ts
@@ -73,7 +73,7 @@ export function formatTMDBMetaResult(
         season_number: v.season_number,
         title: v.name,
       })),
-      poster: (details as TMDBMovieData).poster_path ?? undefined,
+      poster: getMediaPoster(show.poster_path) ?? undefined,
       original_release_year: new Date(show.first_air_date).getFullYear(),
     };
   }


### PR DESCRIPTION
it would seem the poster path for show meta during the formatting specifically was overlooked here while migrating functions around in the codebase