### PR TITLE
Update flixhq.ts

### DIFF
--- a/src/backend/providers/flixhq.ts
+++ b/src/backend/providers/flixhq.ts
@@ -9,7 +9,7 @@ import { registerProvider } from "../helpers/register";
 import { MWCaption, MWStreamQuality, MWStreamType } from "../helpers/streams";
 import { MWMediaType } from "../metadata/types/mw";
 
-const flixHqBase = "https://consumet-api-clone.vercel.app/meta/tmdb"; // instance stolen from streaminal :)
+const flixHqBase = "https://consumet-api-clone-six.vercel.app/meta/tmdb"; // instance stolen from streaminal :)
 
 type FlixHQMediaType = "Movie" | "TV Series";
 interface FLIXMediaBase {


### PR DESCRIPTION
flixHqBase changed.

Old: `https://consumet-api-clone.vercel.app`
New: `https://consumet-api-clone-six.vercel.app`
