### PR TITLE
Add playlist download filename

### DIFF
--- a/src/components/player/atoms/settings/Downloads.tsx
+++ b/src/components/player/atoms/settings/Downloads.tsx
@@ -43,6 +43,7 @@ export function DownloadView({ id }: { id: string }) {
   const { t } = useTranslation();
   const downloadUrl = useDownloadLink();
 
+  const tmdbId = usePlayerStore((s) => s.meta?.tmdbId);
   const sourceType = usePlayerStore((s) => s.source?.type);
   const selectedCaption = usePlayerStore((s) => s.caption?.selected);
   const subtitleUrl = useMemo(
@@ -68,7 +69,12 @@ export function DownloadView({ id }: { id: string }) {
                 <StyleTrans k="player.menus.downloads.hlsDisclaimer" />
               </Menu.Paragraph>
 
-              <Button className="w-full" href={downloadUrl} theme="purple">
+              <Button
+                className="w-full"
+                href={downloadUrl}
+                theme="purple"
+                download={`playlist-${tmdbId}.m3u8`}
+              >
                 {t("player.menus.downloads.downloadPlaylist")}
               </Button>
               <Button


### PR DESCRIPTION
Playlists were apparently playing in-browser for some users, adding the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download) should fix it. Issue discussed on the Discord end.

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
