### PR TITLE
Add darker gray to subtitle colors

### DIFF
--- a/src/components/player/atoms/settings/CaptionSettingsView.tsx
+++ b/src/components/player/atoms/settings/CaptionSettingsView.tsx
@@ -214,7 +214,7 @@ export function CaptionSetting(props: {
   );
 }
 
-export const colors = ["#ffffff", "#80b1fa", "#e2e535"];
+export const colors = ["#a8a8a8", "#ffffff", "#80b1fa", "#e2e535"];
 
 export function CaptionSettingsView({ id }: { id: string }) {
   const { t } = useTranslation();


### PR DESCRIPTION
This pull request resolves #438

Adds a new darker gray (#a8a8a8) to subtitle colors for a more toned down look.

Initially agreed on adding #B0B0B0, but after testing, seems there is an issue with the `CaptionSetting` component which messes up with certain hex colors, if necessary I'll investigate further and add it to this PR, 

![image](https://github.com/movie-web/movie-web/assets/72168435/9dc4319e-1bd3-4299-8890-eac3ef19a230)


 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
