### PR TITLE
Added installation requirements on ReadMe before running pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Content is fetched from third parties and scraping is fully done on the client. 
 - To keep it cheap to host, amount of proxied requests need to be kept to a minimum
 - Also to keep it cheap, no content must ever be streamed through the proxy. So only streams not protected by CORS headers.
 
+# 📋 Requirements for running locally
+- If you don't have `pnpm` installed, you can follow the [instructions here](https://pnpm.io/installation).
+- You also need to [install NodeJS](https://nodejs.org/en/download).
+
 # 🧬 Running locally for development
 
 To run locally, you must first clone the repository. After that run the following commands in the root of the repository:


### PR DESCRIPTION
This pull request resolves the missing installation needed for someone who started from scratch, meaning no web development frameworks were installed. So, in this PR, I added where to install `pnpm` and `NodeJS`. You can change the emoji if you want. Thanks.

 - [ x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [ x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [ x] I have tested all of my changes.
