### PR TITLE
Fix error messages for providers api

### DIFF
--- a/src/hooks/useProviderScrape.tsx
+++ b/src/hooks/useProviderScrape.tsx
@@ -23,7 +23,7 @@ export interface ScrapingSegment {
   embedId?: string;
   status: "failure" | "pending" | "notfound" | "success" | "waiting";
   reason?: string;
-  error?: unknown;
+  error?: any;
   percentage: number;
 }
 

--- a/src/pages/parts/player/ScrapeErrorPart.tsx
+++ b/src/pages/parts/player/ScrapeErrorPart.tsx
@@ -35,6 +35,8 @@ export function ScrapeErrorPart(props: ScrapeErrorPartProps) {
     Object.values(data.sources).forEach((v) => {
       str += `${v.id}: ${v.status}\n`;
       if (v.reason) str += `${v.reason}\n`;
+      if (v.error?.message)
+        str += `${v.error.name ?? "unknown"}: ${v.error.message}\n`;
       if (v.error) str += `${v.error.toString()}\n`;
     });
     return str;


### PR DESCRIPTION
changes:
 - Read message from an object instead of assuming its an actual Error instance.
 - This does **not** fix the issue that the providers API doesn't actually send error information. but once we fix that, it will not need fix clientside anymore (as this pr does it :eyes:)
