### PR TITLE
- Fixed Sidebar scroll effect for last element in the settingLinks

### DIFF
--- a/src/pages/parts/settings/SidebarPart.tsx
+++ b/src/pages/parts/settings/SidebarPart.tsx
@@ -82,17 +82,20 @@ export function SidebarPart() {
           const el = document.getElementById(link.id);
           if (!el) return { distance: Infinity, link: link.id };
           const rect = el.getBoundingClientRect();
-
           const distanceTop = Math.abs(centerTarget - rect.top);
           const distanceBottom = Math.abs(centerTarget - rect.bottom);
-
           const distance = Math.min(distanceBottom, distanceTop);
           return { distance, link: link.id };
         })
         .sort((a, b) => a.distance - b.distance);
 
-      // shortest distance to the part of the screen we want is the active link
-      setActiveLink(viewList[0]?.link ?? "");
+      // Check if user has scrolled past the bottom of the page
+      if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
+        setActiveLink(settingLinks[settingLinks.length - 1].id);
+      } else {
+        // shortest distance to the part of the screen we want is the active link
+        setActiveLink(viewList[0]?.link ?? "");
+      }
     }
     document.addEventListener("scroll", recheck);
     recheck();


### PR DESCRIPTION
### Issue
Currently, on the Settings page - the last element in the Sidebar ("Connections") is not highlighted when you click on it or scroll to the bottom of the page.

### Fix
Added a conditional that checks if user has scrolled to the bottom or clicks on the last element on the sidebar, it will highlight the last element from the settingLinks object.