### PR TITLE
Fix translation keys

### DIFF
--- a/src/components/player/atoms/settings/Downloads.tsx
+++ b/src/components/player/atoms/settings/Downloads.tsx
@@ -78,7 +78,7 @@ export function DownloadView({ id }: { id: string }) {
                 theme="secondary"
                 download="subtitles.srt"
               >
-                {t("player.menus.downloads.downloadCaption")}
+                {t("player.menus.downloads.downloadSubtitle")}
               </Button>
             </>
           ) : (
@@ -113,7 +113,7 @@ export function DownloadView({ id }: { id: string }) {
                 theme="secondary"
                 download="subtitles.srt"
               >
-                {t("player.menus.downloads.downloadCaption")}
+                {t("player.menus.downloads.downloadSubtitle")}
               </Button>
             </>
           )}


### PR DESCRIPTION
Before: 
![image](https://github.com/movie-web/movie-web/assets/49074962/66522038-7824-40ec-8e1e-3903e4d62989)

After: 
![image](https://github.com/movie-web/movie-web/assets/49074962/64e9bdfd-8616-4b56-baec-3383ba0876e6)

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
