### PR TITLE
add value for extra in day for english locale

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -120,7 +120,10 @@
     },
     "titles": {
       "day": {
-        "default": "What would you like to watch this afternoon?"
+        "default": "What would you like to watch this afternoon?",
+        "extra": [
+          "Feeling adventurous? Jurassic Park might be the perfect choice."
+        ]
       },
       "morning": {
         "default": "What would you like to watch this morning?",


### PR DESCRIPTION
This pull request resolves #XXX

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.

## Added missing value for 'Extra' in the 'Day' section in the English locale
