### PR TITLE
Fix the padding top of the lightbar

### DIFF
--- a/src/components/utils/Lightbar.tsx
+++ b/src/components/utils/Lightbar.tsx
@@ -224,7 +224,7 @@ function ParticlesCanvas() {
 export function Lightbar(props: { className?: string }) {
   return (
     <div className="absolute inset-0 w-full h-[680px] overflow-hidden pointer-events-none -mt-64">
-      <div className="max-w-screen w-full h-[680px] relative pt-64">
+      <div className="max-w-screen w-full h-[680px] relative pt-48">
         <div className={props.className}>
           <div className="lightbar">
             <ParticlesCanvas />


### PR DESCRIPTION
- Modified the "pt_64" to the "pt-48"

# What's changed ?
## Before the change
![image](https://github.com/movie-web/movie-web/assets/42072211/5957100f-b290-4dd1-98c0-4baf074d819b)

## After the change
![image](https://github.com/movie-web/movie-web/assets/42072211/26b2be3f-9929-439d-8fac-658640246709)


This pull request resolves #XXX

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
