### PR TITLE
Add semver extension version checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-sticky-el": "^2.1.0",
     "react-turnstile": "^1.1.2",
     "react-use": "^17.4.2",
+    "semver": "^7.5.4",
     "slugify": "^1.6.6",
     "subsrt-ts": "^2.1.2",
     "zustand": "^4.4.7"
@@ -87,6 +88,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/react-stickynode": "^4.0.3",
     "@types/react-transition-group": "^4.4.10",
+    "@types/semver": "^7.5.6",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
     "@vitejs/plugin-react": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ dependencies:
   react-use:
     specifier: ^17.4.2
     version: 17.4.2(react-dom@18.2.0)(react@18.2.0)
+  semver:
+    specifier: ^7.5.4
+    version: 7.5.4
   slugify:
     specifier: ^1.6.6
     version: 1.6.6
@@ -191,6 +194,9 @@ devDependencies:
   '@types/react-transition-group':
     specifier: ^4.4.10
     version: 4.4.10
+  '@types/semver':
+    specifier: ^7.5.6
+    version: 7.5.6
   '@typescript-eslint/eslint-plugin':
     specifier: ^6.15.0
     version: 6.15.0(@typescript-eslint/parser@6.15.0)(eslint@8.56.0)(typescript@5.3.3)
@@ -259,7 +265,7 @@ devDependencies:
     version: 0.5.9(prettier@3.1.1)
   rollup-plugin-visualizer:
     specifier: ^5.11.0
-    version: 5.11.0(@rollup/wasm-node@4.9.5)
+    version: 5.11.0(@rollup/wasm-node@4.9.6)
   tailwind-scrollbar:
     specifier: ^3.0.5
     version: 3.0.5(tailwindcss@3.4.0)
@@ -2048,7 +2054,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /@rollup/plugin-babel@5.3.1(@babel/core@7.23.6)(@rollup/wasm-node@4.9.5):
+  /@rollup/plugin-babel@5.3.1(@babel/core@7.23.6)(@rollup/wasm-node@4.9.6):
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -2061,36 +2067,36 @@ packages:
     dependencies:
       '@babel/core': 7.23.6
       '@babel/helper-module-imports': 7.22.15
-      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.9.5)
-      rollup: /@rollup/wasm-node@4.9.5
+      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.9.6)
+      rollup: /@rollup/wasm-node@4.9.6
     dev: true
 
-  /@rollup/plugin-node-resolve@11.2.1(@rollup/wasm-node@4.9.5):
+  /@rollup/plugin-node-resolve@11.2.1(@rollup/wasm-node@4.9.6):
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       rollup: npm:@rollup/wasm-node
     dependencies:
-      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.9.5)
+      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.9.6)
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.4
-      rollup: /@rollup/wasm-node@4.9.5
+      rollup: /@rollup/wasm-node@4.9.6
     dev: true
 
-  /@rollup/plugin-replace@2.4.2(@rollup/wasm-node@4.9.5):
+  /@rollup/plugin-replace@2.4.2(@rollup/wasm-node@4.9.6):
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
       rollup: npm:@rollup/wasm-node
     dependencies:
-      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.9.5)
+      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.9.6)
       magic-string: 0.25.9
-      rollup: /@rollup/wasm-node@4.9.5
+      rollup: /@rollup/wasm-node@4.9.6
     dev: true
 
-  /@rollup/pluginutils@3.1.0(@rollup/wasm-node@4.9.5):
+  /@rollup/pluginutils@3.1.0(@rollup/wasm-node@4.9.6):
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
@@ -2099,7 +2105,7 @@ packages:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: /@rollup/wasm-node@4.9.5
+      rollup: /@rollup/wasm-node@4.9.6
     dev: true
 
   /@rollup/wasm-node@4.9.4:
@@ -2112,8 +2118,8 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /@rollup/wasm-node@4.9.5:
-    resolution: {integrity: sha512-Xhabb9BwobkC3NFnI9spB+AvHt+iXruRAtBZRlrCDaBnkT7hWUcSF+J+T/nW/qqqGKtYJ/1RzBRv6vCCxEIgpg==}
+  /@rollup/wasm-node@4.9.6:
+    resolution: {integrity: sha512-B3FpAkroTE6q+MRHzv8XLBgPbxdjJiy5UnduZNQ/4lxeF1JT2O/OAr0JPpXeRG/7zpKm/kdqU/4m6AULhmnSqw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     dependencies:
@@ -2334,8 +2340,8 @@ packages:
   /@types/scheduler@0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
 
-  /@types/semver@7.5.1:
-    resolution: {integrity: sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==}
+  /@types/semver@7.5.6:
+    resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
     dev: true
 
   /@types/trusted-types@2.0.3:
@@ -2454,7 +2460,7 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.1
+      '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.15.0
       '@typescript-eslint/types': 6.15.0
       '@typescript-eslint/typescript-estree': 6.15.0(typescript@5.3.3)
@@ -5033,7 +5039,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: true
 
   /magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
@@ -5079,7 +5084,7 @@ packages:
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.6)
       '@babel/types': 7.23.6
       kleur: 4.1.5
-      rollup: /@rollup/wasm-node@4.9.5
+      rollup: /@rollup/wasm-node@4.9.6
       unplugin: 1.5.1
     transitivePeerDependencies:
       - supports-color
@@ -6007,7 +6012,7 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup-plugin-terser@7.0.2(@rollup/wasm-node@4.9.5):
+  /rollup-plugin-terser@7.0.2(@rollup/wasm-node@4.9.6):
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
     peerDependencies:
@@ -6015,12 +6020,12 @@ packages:
     dependencies:
       '@babel/code-frame': 7.23.5
       jest-worker: 26.6.2
-      rollup: /@rollup/wasm-node@4.9.5
+      rollup: /@rollup/wasm-node@4.9.6
       serialize-javascript: 4.0.0
       terser: 5.19.3
     dev: true
 
-  /rollup-plugin-visualizer@5.11.0(@rollup/wasm-node@4.9.5):
+  /rollup-plugin-visualizer@5.11.0(@rollup/wasm-node@4.9.6):
     resolution: {integrity: sha512-exM0Ms2SN3AgTzMeW7y46neZQcyLY7eKwWAop1ZoRTCZwyrIRdMMJ6JjToAJbML77X/9N8ZEpmXG4Z/Clb9k8g==}
     engines: {node: '>=14'}
     hasBin: true
@@ -6032,7 +6037,7 @@ packages:
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
-      rollup: /@rollup/wasm-node@4.9.5
+      rollup: /@rollup/wasm-node@4.9.6
       source-map: 0.7.4
       yargs: 17.7.2
     dev: true
@@ -6146,7 +6151,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /serialize-javascript@4.0.0:
     resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
@@ -7015,7 +7019,7 @@ packages:
       '@types/node': 20.10.5
       esbuild: 0.19.10
       postcss: 8.4.32
-      rollup: /@rollup/wasm-node@4.9.5
+      rollup: /@rollup/wasm-node@4.9.6
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -7277,9 +7281,9 @@ packages:
       '@babel/core': 7.23.6
       '@babel/preset-env': 7.23.6(@babel/core@7.23.6)
       '@babel/runtime': 7.23.6
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.23.6)(@rollup/wasm-node@4.9.5)
-      '@rollup/plugin-node-resolve': 11.2.1(@rollup/wasm-node@4.9.5)
-      '@rollup/plugin-replace': 2.4.2(@rollup/wasm-node@4.9.5)
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.23.6)(@rollup/wasm-node@4.9.6)
+      '@rollup/plugin-node-resolve': 11.2.1(@rollup/wasm-node@4.9.6)
+      '@rollup/plugin-replace': 2.4.2(@rollup/wasm-node@4.9.6)
       '@surma/rollup-plugin-off-main-thread': 2.2.3
       ajv: 8.12.0
       common-tags: 1.8.2
@@ -7288,8 +7292,8 @@ packages:
       glob: 7.2.3
       lodash: 4.17.21
       pretty-bytes: 5.6.0
-      rollup: /@rollup/wasm-node@4.9.5
-      rollup-plugin-terser: 7.0.2(@rollup/wasm-node@4.9.5)
+      rollup: /@rollup/wasm-node@4.9.6
+      rollup-plugin-terser: 7.0.2(@rollup/wasm-node@4.9.6)
       source-map: 0.8.0-beta.0
       stringify-object: 3.3.0
       strip-comments: 2.0.1
@@ -7456,7 +7460,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
 
   /yaml@2.3.2:
     resolution: {integrity: sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==}

--- a/src/backend/extension/compatibility.ts
+++ b/src/backend/extension/compatibility.ts
@@ -1,5 +1,7 @@
-const allowedExtensionVersion = ["0.0.1"];
+import { satisfies } from "semver";
+
+const allowedExtensionRange = "~1.0";
 
 export function isAllowedExtensionVersion(version: string): boolean {
-  return allowedExtensionVersion.includes(version);
+  return satisfies(version, allowedExtensionRange);
 }

--- a/src/backend/extension/compatibility.ts
+++ b/src/backend/extension/compatibility.ts
@@ -1,6 +1,6 @@
 import { satisfies } from "semver";
 
-const allowedExtensionRange = "~1.0";
+const allowedExtensionRange = "~1.0.0";
 
 export function isAllowedExtensionVersion(version: string): boolean {
   return satisfies(version, allowedExtensionRange);


### PR DESCRIPTION
Changes extension version checking to use semver to allow versions to be updated without self-hosters breaking (As long as the change is compatible)