### PR TITLE
Fixed Sorting Shows

### DIFF
--- a/src/backend/accounts/user.ts
+++ b/src/backend/accounts/user.ts
@@ -100,29 +100,22 @@ export function progressResponsesToEntries(responses: ProgressResponse[]) {
     }
 
     if (item.type === "show" && v.season.id && v.episode.id) {
-      if (
-        !item.seasons[v.season.id] ||
-        (item.episodes[v.episode.id] &&
-          new Date(v.updatedAt).getTime() >
-            item.episodes[v.episode.id].updatedAt)
-      ) {
-        item.seasons[v.season.id] = {
-          id: v.season.id,
-          number: v.season.number ?? 0,
-          title: "",
-        };
-        item.episodes[v.episode.id] = {
-          id: v.episode.id,
-          number: v.episode.number ?? 0,
-          title: "",
-          progress: {
-            duration: Number(v.duration),
-            watched: Number(v.watched),
-          },
-          seasonId: v.season.id,
-          updatedAt: new Date(v.updatedAt).getTime(),
-        };
-      }
+      item.seasons[v.season.id] = {
+        id: v.season.id,
+        number: v.season.number ?? 0,
+        title: "",
+      };
+      item.episodes[v.episode.id] = {
+        id: v.episode.id,
+        number: v.episode.number ?? 0,
+        title: "",
+        progress: {
+          duration: Number(v.duration),
+          watched: Number(v.watched),
+        },
+        seasonId: v.season.id,
+        updatedAt: new Date(v.updatedAt).getTime(),
+      };
     }
   });
 

--- a/src/backend/accounts/user.ts
+++ b/src/backend/accounts/user.ts
@@ -87,7 +87,9 @@ export function progressResponsesToEntries(responses: ProgressResponse[]) {
     }
 
     const item = items[v.tmdbId];
-    // Update the item only if the new update is more recent than the current one
+
+    // Since each watched episode is a single array entry but with the same tmdbId, the root item updatedAt will only have the first episode's timestamp (which is not the newest).
+    // Here, we are setting it explicitly so the updatedAt always has the highest updatedAt from the episodes.
     if (new Date(v.updatedAt).getTime() > item.updatedAt) {
       item.updatedAt = new Date(v.updatedAt).getTime();
     }

--- a/src/backend/accounts/user.ts
+++ b/src/backend/accounts/user.ts
@@ -87,6 +87,11 @@ export function progressResponsesToEntries(responses: ProgressResponse[]) {
     }
 
     const item = items[v.tmdbId];
+    // Update the item only if the new update is more recent than the current one
+    if (new Date(v.updatedAt).getTime() > item.updatedAt) {
+      item.updatedAt = new Date(v.updatedAt).getTime();
+    }
+
     if (item.type === "movie") {
       item.progress = {
         duration: Number(v.duration),
@@ -95,22 +100,29 @@ export function progressResponsesToEntries(responses: ProgressResponse[]) {
     }
 
     if (item.type === "show" && v.season.id && v.episode.id) {
-      item.seasons[v.season.id] = {
-        id: v.season.id,
-        number: v.season.number ?? 0,
-        title: "",
-      };
-      item.episodes[v.episode.id] = {
-        id: v.episode.id,
-        number: v.episode.number ?? 0,
-        title: "",
-        progress: {
-          duration: Number(v.duration),
-          watched: Number(v.watched),
-        },
-        seasonId: v.season.id,
-        updatedAt: new Date(v.updatedAt).getTime(),
-      };
+      if (
+        !item.seasons[v.season.id] ||
+        (item.episodes[v.episode.id] &&
+          new Date(v.updatedAt).getTime() >
+            item.episodes[v.episode.id].updatedAt)
+      ) {
+        item.seasons[v.season.id] = {
+          id: v.season.id,
+          number: v.season.number ?? 0,
+          title: "",
+        };
+        item.episodes[v.episode.id] = {
+          id: v.episode.id,
+          number: v.episode.number ?? 0,
+          title: "",
+          progress: {
+            duration: Number(v.duration),
+            watched: Number(v.watched),
+          },
+          seasonId: v.season.id,
+          updatedAt: new Date(v.updatedAt).getTime(),
+        };
+      }
     }
   });
 


### PR DESCRIPTION
This pull request resolves Shows not updating in the Continue Watching List. The issue is let's say for example

I am on season three of Show B
I watch a new show called Show A
I go back to Show B and watch an episode or two of Show B
When I go to the home screen Show B is now on the top. 
On refresh Show B goes back to where it was before, and is not updated on the list.



 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
