### PR TITLE
Copy playlist link

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -128,15 +128,11 @@
       },
       "morning": {
         "default": "What would you like to watch this morning?",
-        "extra": [
-          "I hear Before Sunrise is good"
-        ]
+        "extra": ["I hear Before Sunrise is good"]
       },
       "night": {
         "default": "What would you like to watch tonight?",
-        "extra": [
-          "Tired? I hear The Exorcist is good."
-        ]
+        "extra": ["Tired? I hear The Exorcist is good."]
       }
     }
   },
@@ -243,7 +239,7 @@
     "menus": {
       "downloads": {
         "disclaimer": "Downloads are taken directly from the provider. movie-web does not have control over how the downloads are provided.",
-        "copyHlsPlaylist": "Copy playlist link",
+        "copyHlsPlaylist": "Copy HLS playlist link",
         "downloadSubtitle": "Download current subtitle",
         "downloadVideo": "Download video",
         "hlsDisclaimer": "Downloads are taken directly from the provider. movie-web does not have control over how the downloads are provided.<br /><br />Please note that you are downloading an HLS playlist, <bold>it is not recommended to download if you are not familiar with advanced streaming formats</bold>. Try different sources for different formats.",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -243,7 +243,7 @@
     "menus": {
       "downloads": {
         "disclaimer": "Downloads are taken directly from the provider. movie-web does not have control over how the downloads are provided.",
-        "downloadPlaylist": "Download playlist",
+        "downloadPlaylist": "Copy playlist link",
         "downloadSubtitle": "Download current subtitle",
         "downloadVideo": "Download video",
         "hlsDisclaimer": "Downloads are taken directly from the provider. movie-web does not have control over how the downloads are provided.<br /><br />Please note that you are downloading an HLS playlist, <bold>it is not recommended to download if you are not familiar with advanced streaming formats</bold>. Try different sources for different formats.",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -243,7 +243,7 @@
     "menus": {
       "downloads": {
         "disclaimer": "Downloads are taken directly from the provider. movie-web does not have control over how the downloads are provided.",
-        "downloadPlaylist": "Copy playlist link",
+        "copyHlsPlaylist": "Copy playlist link",
         "downloadSubtitle": "Download current subtitle",
         "downloadVideo": "Download video",
         "hlsDisclaimer": "Downloads are taken directly from the provider. movie-web does not have control over how the downloads are provided.<br /><br />Please note that you are downloading an HLS playlist, <bold>it is not recommended to download if you are not familiar with advanced streaming formats</bold>. Try different sources for different formats.",

--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -7,7 +7,9 @@ import { Spinner } from "@/components/layout/Spinner";
 
 interface Props {
   icon?: Icons;
-  onClick?: () => void;
+  onClick?: (
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement, MouseEvent>,
+  ) => void;
   children?: ReactNode;
   theme?: "white" | "purple" | "secondary" | "danger";
   padding?: string;
@@ -21,11 +23,19 @@ interface Props {
 export function Button(props: Props) {
   const navigate = useNavigate();
   const { onClick, href, loading } = props;
-  const cb = useCallback(() => {
-    if (loading) return;
-    if (href) navigate(href);
-    else onClick?.();
-  }, [onClick, href, navigate, loading]);
+  const cb = useCallback(
+    (
+      event: React.MouseEvent<
+        HTMLAnchorElement | HTMLButtonElement,
+        MouseEvent
+      >,
+    ) => {
+      if (loading) return;
+      if (href && !onClick) navigate(href);
+      else onClick?.(event);
+    },
+    [onClick, href, navigate, loading],
+  );
 
   let colorClasses = "bg-white hover:bg-gray-200 text-black";
   if (props.theme === "purple")
@@ -80,6 +90,7 @@ export function Button(props: Props) {
         target="_blank"
         rel="noreferrer"
         download={props.download}
+        onClick={cb}
       >
         {content}
       </a>

--- a/src/components/player/atoms/settings/Downloads.tsx
+++ b/src/components/player/atoms/settings/Downloads.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
+import { useCopyToClipboard } from "react-use";
 
 import { Button } from "@/components/buttons/Button";
 import { Icon, Icons } from "@/components/Icon";
@@ -43,6 +44,7 @@ export function DownloadView({ id }: { id: string }) {
   const router = useOverlayRouter(id);
   const { t } = useTranslation();
   const downloadUrl = useDownloadLink();
+  const [, copyToClipboard] = useCopyToClipboard();
 
   const sourceType = usePlayerStore((s) => s.source?.type);
   const selectedCaption = usePlayerStore((s) => s.caption?.selected);
@@ -77,7 +79,7 @@ export function DownloadView({ id }: { id: string }) {
                   // Allow context menu & left click to copy
                   event.preventDefault();
 
-                  navigator.clipboard.writeText(downloadUrl);
+                  copyToClipboard(downloadUrl);
                 }}
               >
                 {t("player.menus.downloads.downloadPlaylist")}

--- a/src/components/player/atoms/settings/Downloads.tsx
+++ b/src/components/player/atoms/settings/Downloads.tsx
@@ -69,7 +69,17 @@ export function DownloadView({ id }: { id: string }) {
                 <StyleTrans k="player.menus.downloads.hlsDisclaimer" />
               </Menu.Paragraph>
 
-              <Button className="w-full" href={downloadUrl} theme="purple">
+              <Button
+                className="w-full"
+                theme="purple"
+                href={downloadUrl}
+                onClick={(event) => {
+                  // Allow context menu & left click to copy
+                  event.preventDefault();
+
+                  navigator.clipboard.writeText(downloadUrl);
+                }}
+              >
                 {t("player.menus.downloads.downloadPlaylist")}
               </Button>
               <Button


### PR DESCRIPTION
This pull request resolves #857 

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.

![image](https://github.com/movie-web/movie-web/assets/49074962/b2912ded-c3a1-40ed-9e50-e5b69fed1b86)
Allows left click and context menu > copy link address to copy.