### PR TITLE
Extend the length of captions

### DIFF
--- a/src/components/player/base/SubtitleView.tsx
+++ b/src/components/player/base/SubtitleView.tsx
@@ -59,7 +59,7 @@ export function CaptionCue({
 
   return (
     <p
-      className="pointer-events-none mb-1 select-none rounded px-8 py-1 text-center leading-normal [text-shadow:0_2px_4px_rgba(0,0,0,0.5)]"
+      className="pointer-events-none mb-1 select-none rounded px-4 py-1 text-center leading-normal [text-shadow:0_2px_4px_rgba(0,0,0,0.5)]"
       style={{
         color: styling.color,
         fontSize: `${(1.5 * styling.size).toFixed(2)}em`,

--- a/src/components/player/base/SubtitleView.tsx
+++ b/src/components/player/base/SubtitleView.tsx
@@ -30,12 +30,21 @@ export function CaptionCue({
       textToUse = text.slice(0, 1) + text.slice(1).toLowerCase();
     }
 
+    let curLength = 0;
+
     const textWithNewlines = (textToUse || "")
       .split(" ")
-      .map((word) => wordOverrides[word] ?? word)
+      .map((word) => {
+        curLength += word.length + 1;
+        word = wordOverrides[word] ?? word;
+        if (curLength > 40) {
+          word = `<br />${word}`;
+          curLength = 0;
+        }
+        return word;
+      })
       .join(" ")
-      .replaceAll(/ i'/g, " I'")
-      .replaceAll(/\r?\n/g, "<br />");
+      .replaceAll(/ i'/g, " I'");
 
     // https://www.w3.org/TR/webvtt1/#dom-construction-rules
     // added a <br /> for newlines
@@ -50,7 +59,7 @@ export function CaptionCue({
 
   return (
     <p
-      className="pointer-events-none mb-1 select-none rounded px-4 py-1 text-center leading-normal [text-shadow:0_2px_4px_rgba(0,0,0,0.5)]"
+      className="pointer-events-none mb-1 select-none rounded px-8 py-1 text-center leading-normal [text-shadow:0_2px_4px_rgba(0,0,0,0.5)]"
       style={{
         color: styling.color,
         fontSize: `${(1.5 * styling.size).toFixed(2)}em`,


### PR DESCRIPTION
This pull request resolves #870 

I tried to extend the size of the box(where the captions are displayed) to make the captions longer, but I found that the size of the box doesn't do anything with making a new line. So, I thought the best way is to change the point when it makes a new line! (like, every 40 characters or 50 or something like that... and since you don't want the last word in a line to be separated in the middle of it when it makes the length more than 40 chars, I'm putting the word in the next line so it will look good!) Maybe, the way how I did it was wrong, but please let me know your appreciation and give me some advice to make it a better way!

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
