### PR TITLE
fix: props.children's type in CaptchaProvider component

### DIFF
--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -15,7 +15,7 @@ import { PageTitle } from "@/pages/parts/util/PageTitle";
 
 function CaptchaProvider(props: {
   siteKey: string | null;
-  children: JSX.Element;
+  children: React.ReactNode;
 }) {
   if (!props.siteKey) return props.children;
   return (


### PR DESCRIPTION
This pull request for `Follow standard best practices for TypeScript and React.`

I've observed `React.ReactNode` being declared for the `props.children` elsewhere in the project, based on my understanding and references on the Internet, I made this change.

reference: https://stackoverflow.com/questions/58123398/when-to-use-jsx-element-vs-reactnode-vs-reactelement

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
