### PR TITLE
Bump compatibility to caret-style for extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movie-web",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "private": true,
   "homepage": "https://movie-web.app",
   "scripts": {

--- a/src/backend/extension/compatibility.ts
+++ b/src/backend/extension/compatibility.ts
@@ -1,6 +1,6 @@
 import { satisfies } from "semver";
 
-const allowedExtensionRange = "~1.0.2";
+const allowedExtensionRange = "^1.0.2";
 
 export function isAllowedExtensionVersion(version: string): boolean {
   return satisfies(version, allowedExtensionRange);


### PR DESCRIPTION
I think tilde version compatibility is too strict, I think using `^1.0.2` will work better as it allows us to go up a patch version without breaking compatibility

As per semver, this should be fine as breaking changes should be a major version change