### PR TITLE
Update the admin page to run workers in parallel

### DIFF
--- a/src/pages/parts/admin/TMDBTestPart.tsx
+++ b/src/pages/parts/admin/TMDBTestPart.tsx
@@ -29,7 +29,7 @@ export function TMDBTestPart() {
       return setStatus({
         hasTested: true,
         success: false,
-        errorText: "TMDB api key is not set",
+        errorText: "TMDB API key is not set",
       });
     }
     const isJWT = tmdbApiKey.split(".").length > 2;
@@ -37,7 +37,7 @@ export function TMDBTestPart() {
       return setStatus({
         hasTested: true,
         success: false,
-        errorText: "TMDB api key is not a read only key",
+        errorText: "TMDB API key is not a read only key",
       });
     }
 
@@ -48,7 +48,7 @@ export function TMDBTestPart() {
         hasTested: true,
         success: false,
         errorText:
-          "Failed to call tmdb, double check api key and your internet connection",
+          "Failed to call TMDB, double check API key and your internet connection",
       });
     }
 
@@ -61,7 +61,7 @@ export function TMDBTestPart() {
 
   return (
     <>
-      <Heading2 className="mb-8 mt-12">TMDB tests</Heading2>
+      <Heading2 className="mb-8 mt-12">TMDB test</Heading2>
       <Box>
         <div className="flex items-center">
           <div className="flex-1">


### PR DESCRIPTION
Changes the admin page to run all worker tests at the same time, allowing for a faster test. Since I fear that people would spam this, I also added a 5 second cooldown period after each test, which disables the button.

Also changed a bit of the TMDB tests grammar.

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
