### PR TITLE
Disable default setup option if no proxies are set, remove extension help once it succeeds

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -1,6 +1,7 @@
 window.__CONFIG__ = {
   // The URL for the CORS proxy, the URL must NOT end with a slash!
-  VITE_CORS_PROXY_URL: "CHANGEME",
+  // If not specified, the onboarding will not allow a "default setup". The user will have to use the extension or set up a proxy themselves
+  VITE_CORS_PROXY_URL: "",
 
   // The READ API key to access TMDB
   VITE_TMDB_READ_API_KEY: "CHANGEME",

--- a/src/pages/onboarding/Onboarding.tsx
+++ b/src/pages/onboarding/Onboarding.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/pages/onboarding/onboardingHooks";
 import { Card, CardContent, Link } from "@/pages/onboarding/utils";
 import { PageTitle } from "@/pages/parts/util/PageTitle";
+import { getProxyUrls } from "@/utils/proxyUrls";
 
 function VerticalLine(props: { className?: string }) {
   return (
@@ -27,6 +28,7 @@ export function OnboardingPage() {
   const skipModal = useModal("skip");
   const { completeAndRedirect } = useRedirectBack();
   const { t } = useTranslation();
+  const noProxies = getProxyUrls().length === 0;
 
   return (
     <MinimalPageLayout>
@@ -85,32 +87,34 @@ export function OnboardingPage() {
             </CardContent>
           </Card>
         </div>
-
-        <p className="text-center hidden md:block mt-12">
-          <Trans i18nKey="onboarding.start.options.default.text">
-            <br />
-            <a
-              onClick={skipModal.show}
-              type="button"
-              className="text-onboarding-link hover:opacity-75 cursor-pointer"
-            />
-          </Trans>
-        </p>
-
-        <div className=" max-w-[300px] mx-auto md:hidden mt-12 ">
-          <Button
-            className="!text-type-text !bg-opacity-50"
-            theme="secondary"
-            onClick={skipModal.show}
-          >
-            <span>
+        {noProxies ? null : (
+          <>
+            <p className="text-center hidden md:block mt-12">
               <Trans i18nKey="onboarding.start.options.default.text">
-                <span />
-                <span />
+                <br />
+                <a
+                  onClick={skipModal.show}
+                  type="button"
+                  className="text-onboarding-link hover:opacity-75 cursor-pointer"
+                />
               </Trans>
-            </span>
-          </Button>
-        </div>
+            </p>
+            <div className=" max-w-[300px] mx-auto md:hidden mt-12 ">
+              <Button
+                className="!text-type-text !bg-opacity-50"
+                theme="secondary"
+                onClick={skipModal.show}
+              >
+                <span>
+                  <Trans i18nKey="onboarding.start.options.default.text">
+                    <span />
+                    <span />
+                  </Trans>
+                </span>
+              </Button>
+            </div>
+          </>
+        )}
       </CenterContainer>
     </MinimalPageLayout>
   );

--- a/src/pages/onboarding/OnboardingExtension.tsx
+++ b/src/pages/onboarding/OnboardingExtension.tsx
@@ -115,7 +115,7 @@ export function ExtensionStatus(props: {
         </div>
       </Card>
       {lastKnownStatus === "unknown" ? <RefreshBar /> : null}
-      {props.showHelp ? (
+      {props.showHelp && props.status !== "success" ? (
         <Card className="mt-4">
           <div className="flex items-center space-x-7">
             <Icon icon={Icons.WARNING} className="text-type-danger text-2xl" />


### PR DESCRIPTION
This PR removes the "I don't want good quality streams, use the default setup" text at the bottom of the onboarding page if no proxies are set by the host. Also removes the extension help once the extension is connected to the site.

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
