### PR TITLE
Fix media download button redirecting to incorrect URL on main tab

### DIFF
--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 import { ReactNode, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { Icon, Icons } from "@/components/Icon";
 import { Spinner } from "@/components/layout/Spinner";

--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -21,7 +21,6 @@ interface Props {
 }
 
 export function Button(props: Props) {
-  const navigate = useNavigate();
   const { onClick, href, loading } = props;
   const cb = useCallback(
     (
@@ -31,10 +30,12 @@ export function Button(props: Props) {
       >,
     ) => {
       if (loading) return;
-      if (href && !onClick) navigate(href);
-      else onClick?.(event);
+      if (href && !onClick) {
+        event.preventDefault();
+        window.open(href, "_blank", "noreferrer");
+      } else onClick?.(event);
     },
-    [onClick, href, navigate, loading],
+    [onClick, href, loading],
   );
 
   let colorClasses = "bg-white hover:bg-gray-200 text-black";


### PR DESCRIPTION
Previously when using the download button for downloading a video, it would open a new tab with the correct URL, but then also append the movie-web tab with the download link:

`http://localhost:5173/media/tmdb-tv-615-futurama/1868/35006/https://uk1-as201-1.shegu.net/vip/p1/tv_mp4_h264/1/9/139/1/tv.139.S1E1.1080p.H264.20220310042329.mp4?KEY1=ky4AD3z221HA4BlHG4ZCAQ&KEY2=1708972370`

This was because we were using `useNavigate()`, switching to `window.open()` fixes this.

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
