### PR TITLE
Make Google Analytics configurable with VITE_GA_ID

### DIFF
--- a/src/setup/constants.ts
+++ b/src/setup/constants.ts
@@ -2,5 +2,5 @@ export const APP_VERSION = import.meta.env.PACKAGE_VERSION;
 export const DISCORD_LINK = "https://discord.gg/gQYB6fGArX";
 export const GITHUB_LINK = "https://github.com/movie-web/movie-web";
 export const DONATION_LINK = "https://ko-fi.com/movieweb";
-export const GA_ID = "G-44YVXRL61C";
+export const GA_ID = import.meta.env.VITE_GA_ID;
 export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;

--- a/src/setup/ga.ts
+++ b/src/setup/ga.ts
@@ -2,8 +2,10 @@ import ReactGA from "react-ga4";
 
 import { GA_ID } from "@/setup/constants";
 
-ReactGA.initialize([
-  {
-    trackingId: GA_ID,
-  },
-]);
+if (GA_ID) {
+  ReactGA.initialize([
+    {
+      trackingId: GA_ID,
+    },
+  ]);
+}


### PR DESCRIPTION
Adds a new environment variable `VITE_GA_ID` which allows you to set your own Google Analytics id. If this is not set, it will disable Google Analytics.

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
