### PR TITLE
Allow users to change volume with scroll wheel

### DIFF
--- a/src/components/player/atoms/Volume.tsx
+++ b/src/components/player/atoms/Volume.tsx
@@ -47,8 +47,22 @@ export function Volume(props: Props) {
   if (dragging) percentage = makePercentage(dragPercentage);
   const percentageString = makePercentageString(percentage);
 
+  const handleWheel = useCallback(
+    (event: React.WheelEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      let newVolume = volume - event.deltaY / 1000;
+      newVolume = Math.max(0, Math.min(newVolume, 1));
+      setVolume(newVolume);
+    },
+    [volume, setVolume],
+  );
+
   return (
-    <div className={props.className} onMouseEnter={handleMouseEnter}>
+    <div
+      className={props.className}
+      onMouseEnter={handleMouseEnter}
+      onWheel={handleWheel}
+    >
       <div className="pointer-events-auto flex cursor-pointer items-center py-0">
         <div className="px-4 text-2xl text-white" onClick={handleClick}>
           <Icon icon={percentage > 0 ? Icons.VOLUME : Icons.VOLUME_X} />


### PR DESCRIPTION
Allows users to use their scroll wheel to change the volume if hovering over the volume div.

This is a little niche, but it matches YouTubes behavior and was requested in our [feature-requests](https://discord.com/channels/871713465100816424/1207094237183742022).

![wheel](https://github.com/movie-web/movie-web/assets/72168435/38447bd4-8931-40e6-ad2c-e34d46be1ac8)

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
