### PR TITLE
Extension: Prepare stream for all domains in a hls playlist

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7359,6 +7359,7 @@ packages:
 
   /workbox-google-analytics@7.0.0:
     resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
     dependencies:
       workbox-background-sync: 7.0.0
       workbox-core: 7.0.0

--- a/src/backend/extension/messaging.ts
+++ b/src/backend/extension/messaging.ts
@@ -6,6 +6,11 @@ import {
 import { isAllowedExtensionVersion } from "@/backend/extension/compatibility";
 import { ExtensionMakeRequestResponse } from "@/backend/extension/plasmo";
 
+export const RULE_IDS = {
+  PREPARE_STREAM: 1,
+  SET_DOMAINS_HLS: 2,
+};
+
 // for some reason, about 500 ms is needed after
 // page load before the extension starts responding properly
 const isExtensionReady = new Promise<void>((resolve) => {

--- a/src/backend/extension/streams.ts
+++ b/src/backend/extension/streams.ts
@@ -1,6 +1,6 @@
 import { Stream } from "@movie-web/providers";
 
-import { setDomainRule } from "@/backend/extension/messaging";
+import { RULE_IDS, setDomainRule } from "@/backend/extension/messaging";
 
 function extractDomain(url: string): string | null {
   try {
@@ -36,7 +36,7 @@ function buildHeadersFromStream(stream: Stream): Record<string, string> {
 
 export async function prepareStream(stream: Stream) {
   await setDomainRule({
-    ruleId: 1,
+    ruleId: RULE_IDS.PREPARE_STREAM,
     targetDomains: extractDomainsFromStream(stream),
     requestHeaders: buildHeadersFromStream(stream),
   });

--- a/src/components/player/display/base.ts
+++ b/src/components/player/display/base.ts
@@ -152,10 +152,9 @@ export function makeVideoElementDisplayInterface(): DisplayInterface {
 
           if (isExtensionActiveCached()) {
             hls.on(Hls.Events.LEVEL_LOADED, async (_, data) => {
-              console.log(data);
-              const chunkUrlsDomains = data.details.fragments
-                .map((v) => v.url)
-                .map((v) => new URL(v).hostname);
+              const chunkUrlsDomains = data.details.fragments.map(
+                (v) => new URL(v.url).hostname,
+              );
               const chunkUrls = [...new Set(chunkUrlsDomains)];
 
               await setDomainRule({

--- a/src/components/player/display/base.ts
+++ b/src/components/player/display/base.ts
@@ -2,6 +2,11 @@ import fscreen from "fscreen";
 import Hls, { Level } from "hls.js";
 
 import {
+  RULE_IDS,
+  isExtensionActiveCached,
+  setDomainRule,
+} from "@/backend/extension/messaging";
+import {
   DisplayInterface,
   DisplayInterfaceEvents,
 } from "@/components/player/display/displayInterface";
@@ -31,8 +36,8 @@ const levelConversionMap: Record<number, SourceQuality> = {
   480: "480",
 };
 
-function hlsLevelToQuality(level: Level): SourceQuality | null {
-  return levelConversionMap[level.height] ?? null;
+function hlsLevelToQuality(level?: Level): SourceQuality | null {
+  return levelConversionMap[level?.height ?? 0] ?? null;
 }
 
 function qualityToHlsLevel(quality: SourceQuality): number | null {
@@ -144,6 +149,25 @@ export function makeVideoElementDisplayInterface(): DisplayInterface {
           if (!hls) return;
           reportLevels();
           setupQualityForHls();
+
+          if (isExtensionActiveCached()) {
+            hls.on(Hls.Events.LEVEL_LOADED, async (_, data) => {
+              console.log(data);
+              const chunkUrlsDomains = data.details.fragments
+                .map((v) => v.url)
+                .map((v) => new URL(v).hostname);
+              const chunkUrls = [...new Set(chunkUrlsDomains)];
+
+              await setDomainRule({
+                ruleId: RULE_IDS.SET_DOMAINS_HLS,
+                targetDomains: chunkUrls,
+                requestHeaders: {
+                  ...src.preferredHeaders,
+                  ...src.headers,
+                },
+              });
+            });
+          }
         });
         hls.on(Hls.Events.LEVEL_SWITCHED, () => {
           if (!hls) return;

--- a/src/components/player/utils/convertRunoutputToSource.ts
+++ b/src/components/player/utils/convertRunoutputToSource.ts
@@ -28,6 +28,7 @@ export function convertRunoutputToSource(out: {
     return {
       type: "hls",
       url: out.stream.playlist,
+      headers: out.stream.headers,
       preferredHeaders: out.stream.preferredHeaders,
     };
   }
@@ -50,6 +51,7 @@ export function convertRunoutputToSource(out: {
     return {
       type: "file",
       qualities,
+      headers: out.stream.headers,
       preferredHeaders: out.stream.preferredHeaders,
     };
   }

--- a/src/stores/player/utils/qualities.ts
+++ b/src/stores/player/utils/qualities.ts
@@ -14,6 +14,7 @@ export type SourceFileStream = {
 export type LoadableSource = {
   type: StreamType;
   url: string;
+  headers?: Stream["headers"];
   preferredHeaders?: Stream["preferredHeaders"];
 };
 
@@ -21,11 +22,13 @@ export type SourceSliceSource =
   | {
       type: "file";
       qualities: Partial<Record<SourceQuality, SourceFileStream>>;
+      headers?: Stream["headers"];
       preferredHeaders?: Stream["preferredHeaders"];
     }
   | {
       type: "hls";
       url: string;
+      headers?: Stream["headers"];
       preferredHeaders?: Stream["preferredHeaders"];
     };
 


### PR DESCRIPTION
This pull request resolves #905 and VidSrcTo

There was also a bug in the hlsLevelQuality function, sometimes levels don't exist and it throws an error which causes the code after not to run.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
