### PR TITLE
feat: allow setting 'base' via VITE_BASE_URL

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -24,6 +24,7 @@ const captioningPackages = [
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd());
   return {
+    base: env.VITE_BASE_URL || '/',
     plugins: [
       million.vite({ auto: true, mute: true }),
       handlebars({


### PR DESCRIPTION
this sets the default to `/` which results in this patch not breaking behavior. This is being used to set base as a relative path to enable hosting movie-web at any non-root location

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
