### PR TITLE
When navigating to own pages, use `useNavigate()`

### DIFF
--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { ReactNode, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { Icon, Icons } from "@/components/Icon";
 import { Spinner } from "@/components/layout/Spinner";
@@ -20,6 +21,7 @@ interface Props {
 }
 
 export function Button(props: Props) {
+  const navigate = useNavigate();
   const { onClick, href, loading } = props;
   const cb = useCallback(
     (
@@ -31,10 +33,14 @@ export function Button(props: Props) {
       if (loading) return;
       if (href && !onClick) {
         event.preventDefault();
-        window.open(href, "_blank", "noreferrer");
+        if (!href.includes("http")) {
+          navigate(href);
+        } else {
+          window.open(href, "_blank", "noreferrer");
+        }
       } else onClick?.(event);
     },
-    [onClick, href, loading],
+    [loading, href, onClick, navigate],
   );
 
   let colorClasses = "bg-white hover:bg-gray-200 text-black";


### PR DESCRIPTION
Resolves a bug that came with https://github.com/movie-web/movie-web/pull/941

When navigating to our own pages, like on an error screen, it would open a new window... because I didn't think of adding an if condition for this.

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
