### PR TITLE
Update CaptionSettingsView.tsx

### DIFF
--- a/src/components/player/atoms/settings/CaptionSettingsView.tsx
+++ b/src/components/player/atoms/settings/CaptionSettingsView.tsx
@@ -234,8 +234,8 @@ export function CaptionSettingsView({ id }: { id: string }) {
       <Menu.Section className="space-y-6">
         <CaptionSetting
           label={t("player.menus.subtitles.settings.delay")}
-          max={10}
-          min={-10}
+          max={60}
+          min={-60}
           onChange={(v) => setDelay(v)}
           value={delay}
           textTransformer={(s) => `${s}s`}


### PR DESCRIPTION
update caption delay limits because some shows(Silicon Valley) had subtitle delay > 10 seconds

This pull request resolves #XXX

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
