### PR TITLE
Add blurred background option for subtitles

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -533,6 +533,7 @@
     },
     "subtitles": {
       "backgroundLabel": "Background opacity",
+      "backgroundBlurLabel": "Background blur",
       "colorLabel": "Color",
       "previewQuote": "I must not fear. Fear is the mind-killer.",
       "textSizeLabel": "Text size",

--- a/src/assets/locales/pl.json
+++ b/src/assets/locales/pl.json
@@ -525,6 +525,7 @@
     },
     "subtitles": {
       "backgroundLabel": "Krycie tła",
+      "backgroundBlurLabel": "Rozmycie tła",
       "colorLabel": "Kolor",
       "previewQuote": "Nie wolno mi się bać. Strach zabija myślenie.",
       "textSizeLabel": "Rozmiar czcionki",

--- a/src/components/player/atoms/settings/CaptionSettingsView.tsx
+++ b/src/components/player/atoms/settings/CaptionSettingsView.tsx
@@ -263,6 +263,18 @@ export function CaptionSettingsView({ id }: { id: string }) {
           textTransformer={(s) => `${s}%`}
         />
         <CaptionSetting
+          label={t("settings.subtitles.backgroundBlurLabel")}
+          max={64}
+          min={0}
+          onChange={(v) =>
+            updateStyling({
+              backgroundBlur: Math.round(v / 4) * 4,
+            })
+          }
+          value={styling.backgroundBlur}
+          textTransformer={(s) => `${s}px`}
+        />
+        <CaptionSetting
           label={t("settings.subtitles.textSizeLabel")}
           max={200}
           min={1}

--- a/src/components/player/atoms/settings/CaptionSettingsView.tsx
+++ b/src/components/player/atoms/settings/CaptionSettingsView.tsx
@@ -264,15 +264,11 @@ export function CaptionSettingsView({ id }: { id: string }) {
         />
         <CaptionSetting
           label={t("settings.subtitles.backgroundBlurLabel")}
-          max={64}
+          max={100}
           min={0}
-          onChange={(v) =>
-            updateStyling({
-              backgroundBlur: Math.round(v / 4) * 4,
-            })
-          }
-          value={styling.backgroundBlur}
-          textTransformer={(s) => `${s}px`}
+          onChange={(v) => updateStyling({ backgroundBlur: v / 100 })}
+          value={styling.backgroundBlur * 100}
+          textTransformer={(s) => `${s}%`}
         />
         <CaptionSetting
           label={t("settings.subtitles.textSizeLabel")}

--- a/src/components/player/base/SubtitleView.tsx
+++ b/src/components/player/base/SubtitleView.tsx
@@ -55,6 +55,10 @@ export function CaptionCue({
         color: styling.color,
         fontSize: `${(1.5 * styling.size).toFixed(2)}em`,
         backgroundColor: `rgba(0,0,0,${styling.backgroundOpacity.toFixed(2)})`,
+        backdropFilter:
+          styling.backgroundBlur !== 0
+            ? `blur(${styling.backgroundBlur}px)`
+            : "none",
       }}
     >
       <span

--- a/src/components/player/base/SubtitleView.tsx
+++ b/src/components/player/base/SubtitleView.tsx
@@ -57,7 +57,7 @@ export function CaptionCue({
         backgroundColor: `rgba(0,0,0,${styling.backgroundOpacity.toFixed(2)})`,
         backdropFilter:
           styling.backgroundBlur !== 0
-            ? `blur(${styling.backgroundBlur}px)`
+            ? `blur(${Math.floor(styling.backgroundBlur * 64)}px)`
             : "none",
       }}
     >

--- a/src/pages/parts/settings/CaptionsPart.tsx
+++ b/src/pages/parts/settings/CaptionsPart.tsx
@@ -94,16 +94,13 @@ export function CaptionsPart(props: {
           />
           <CaptionSetting
             label={t("settings.subtitles.backgroundBlurLabel")}
-            max={64}
+            max={100}
             min={0}
             onChange={(v) =>
-              props.setStyling({
-                ...props.styling,
-                backgroundBlur: Math.round(v / 4) * 4,
-              })
+              props.setStyling({ ...props.styling, backgroundBlur: v / 100 })
             }
-            value={props.styling.backgroundBlur}
-            textTransformer={(s) => `${s}px`}
+            value={props.styling.backgroundBlur * 100}
+            textTransformer={(s) => `${s}%`}
           />
           <CaptionSetting
             label={t("settings.subtitles.textSizeLabel")}

--- a/src/pages/parts/settings/CaptionsPart.tsx
+++ b/src/pages/parts/settings/CaptionsPart.tsx
@@ -93,6 +93,19 @@ export function CaptionsPart(props: {
             textTransformer={(s) => `${s}%`}
           />
           <CaptionSetting
+            label={t("settings.subtitles.backgroundBlurLabel")}
+            max={64}
+            min={0}
+            onChange={(v) =>
+              props.setStyling({
+                ...props.styling,
+                backgroundBlur: Math.round(v / 4) * 4,
+              })
+            }
+            value={props.styling.backgroundBlur}
+            textTransformer={(s) => `${s}px`}
+          />
+          <CaptionSetting
             label={t("settings.subtitles.textSizeLabel")}
             max={200}
             min={1}

--- a/src/stores/subtitles/index.ts
+++ b/src/stores/subtitles/index.ts
@@ -17,6 +17,11 @@ export interface SubtitleStyling {
    * background opacity, ranges between 0 and 1
    */
   backgroundOpacity: number;
+
+  /**
+   * background blur, ranges between 0 and 64
+   */
+  backgroundBlur: number;
 }
 
 export interface SubtitleStore {
@@ -51,6 +56,7 @@ export const useSubtitleStore = create(
         color: "#ffffff",
         backgroundOpacity: 0.5,
         size: 1,
+        backgroundBlur: 0,
       },
       resetSubtitleSpecificSettings() {
         set((s) => {
@@ -62,6 +68,8 @@ export const useSubtitleStore = create(
         set((s) => {
           if (newStyling.backgroundOpacity !== undefined)
             s.styling.backgroundOpacity = newStyling.backgroundOpacity;
+          if (newStyling.backgroundBlur !== undefined)
+            s.styling.backgroundBlur = newStyling.backgroundBlur;
           if (newStyling.color !== undefined)
             s.styling.color = newStyling.color.toLowerCase();
           if (newStyling.size !== undefined)

--- a/src/stores/subtitles/index.ts
+++ b/src/stores/subtitles/index.ts
@@ -56,7 +56,7 @@ export const useSubtitleStore = create(
         color: "#ffffff",
         backgroundOpacity: 0.5,
         size: 1,
-        backgroundBlur: 0,
+        backgroundBlur: 0.5,
       },
       resetSubtitleSpecificSettings() {
         set((s) => {

--- a/src/stores/subtitles/index.ts
+++ b/src/stores/subtitles/index.ts
@@ -19,7 +19,7 @@ export interface SubtitleStyling {
   backgroundOpacity: number;
 
   /**
-   * background blur, ranges between 0 and 64
+   * background blur, ranges between 0 and 1
    */
   backgroundBlur: number;
 }


### PR DESCRIPTION
This pull request resolves #841

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.

# Preview
![subtitle-blur-animation-1](https://github.com/movie-web/movie-web/assets/95639019/becacd92-c8a2-4646-b00f-7efec96758e5)
![subtitle-blur-animation-2](https://github.com/movie-web/movie-web/assets/95639019/b1d9429d-7ac3-4dea-b5ac-bf698efb68e5)

The blur ranges from 0 to 64 pixels.


This also obviously needs a localization entry in the json files, so I added one in the files for the languages I speak.