### PR TITLE
Fix Nan% in Background Blur

### DIFF
--- a/src/components/player/base/SubtitleView.tsx
+++ b/src/components/player/base/SubtitleView.tsx
@@ -57,7 +57,7 @@ export function CaptionCue({
         backgroundColor: `rgba(0,0,0,${styling.backgroundOpacity.toFixed(2)})`,
         backdropFilter:
           styling.backgroundBlur !== 0
-            ? `blur(${Math.floor(styling.backgroundBlur * 64)}px)`
+            ? `blur(${Math.floor(styling.backgroundBlur * 64).toFixed(2)}px)`
             : "none",
       }}
     >


### PR DESCRIPTION
This pull request resolves #XXX

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.

Fixes the bugged Nan%

This issue only appeared on firefox on pc (wasnt a problem on edge/chrome)
Havent tested on mobile

Before : 
![image](https://github.com/movie-web/movie-web/assets/94032937/f18c6a82-b9e6-4874-b908-d4547ac47d99)

After
![image](https://github.com/movie-web/movie-web/assets/94032937/88bed44f-059b-4995-aed4-f43951d782bf)
