### PR TITLE
Add check for setPositionState to avoid TypeError

### DIFF
--- a/src/components/player/internals/MediaSession.tsx
+++ b/src/components/player/internals/MediaSession.tsx
@@ -32,6 +32,9 @@ export function MediaSession() {
 
   const updatePositionState = useCallback(
     (position: number) => {
+      // If the browser doesn't support setPositionState, return
+      if (typeof navigator.mediaSession.setPositionState !== "function") return;
+
       // If the updated position needs to be buffered, queue an update
       if (position > data.progress.buffered) {
         shouldUpdatePositionState.current = true;


### PR DESCRIPTION
Apparently some TVs have support for MediaSession, but don't support `setPositionState`, so we add a check to return if so.

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
