### PR TITLE
Add logic for same year not released and fix language string

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -148,6 +148,7 @@
   },
   "media": {
     "episodeDisplay": "S{{season}} E{{episode}}",
+    "unreleased": "Unreleased",
     "types": {
       "movie": "Movie",
       "show": "Show"

--- a/src/backend/metadata/getmeta.ts
+++ b/src/backend/metadata/getmeta.ts
@@ -43,7 +43,7 @@ export function formatTMDBMetaResult(
       title: movie.title,
       object_type: mediaTypeToTMDB(type),
       poster: getMediaPoster(movie.poster_path) ?? undefined,
-      original_release_year: new Date(movie.release_date).getFullYear(),
+      original_release_date: new Date(movie.release_date),
     };
   }
   if (type === MWMediaType.SERIES) {
@@ -58,7 +58,7 @@ export function formatTMDBMetaResult(
         title: v.name,
       })),
       poster: getMediaPoster(show.poster_path) ?? undefined,
-      original_release_year: new Date(show.first_air_date).getFullYear(),
+      original_release_date: new Date(show.first_air_date),
     };
   }
 

--- a/src/backend/metadata/tmdb.ts
+++ b/src/backend/metadata/tmdb.ts
@@ -66,7 +66,7 @@ export function formatTMDBMeta(
   return {
     title: media.title,
     id: media.id.toString(),
-    year: media.original_release_year?.toString(),
+    year: media.original_release_date?.getFullYear()?.toString(),
     poster: media.poster,
     type,
     seasons: seasons as any,
@@ -94,7 +94,8 @@ export function formatTMDBMetaToMediaItem(media: TMDBMediaResult): MediaItem {
   return {
     title: media.title,
     id: media.id.toString(),
-    year: media.original_release_year ?? 0,
+    year: media.original_release_date?.getFullYear() ?? 0,
+    release_date: media.original_release_date,
     poster: media.poster,
     type,
   };
@@ -260,7 +261,7 @@ export function formatTMDBSearchResult(
       title: show.name,
       poster: getMediaPoster(show.poster_path),
       id: show.id,
-      original_release_year: new Date(show.first_air_date).getFullYear(),
+      original_release_date: new Date(show.first_air_date),
       object_type: mediatype,
     };
   }
@@ -271,7 +272,7 @@ export function formatTMDBSearchResult(
     title: movie.title,
     poster: getMediaPoster(movie.poster_path),
     id: movie.id,
-    original_release_year: new Date(movie.release_date).getFullYear(),
+    original_release_date: new Date(movie.release_date),
     object_type: mediatype,
   };
 }

--- a/src/backend/metadata/types/tmdb.ts
+++ b/src/backend/metadata/types/tmdb.ts
@@ -20,7 +20,7 @@ export type TMDBMediaResult = {
   title: string;
   poster?: string;
   id: number;
-  original_release_year?: number;
+  original_release_date?: Date;
   object_type: TMDBContentTypes;
   seasons?: TMDBSeasonShort[];
 };

--- a/src/utils/mediaTypes.ts
+++ b/src/utils/mediaTypes.ts
@@ -2,6 +2,7 @@ export interface MediaItem {
   id: string;
   title: string;
   year?: number;
+  release_date?: Date;
   poster?: string;
   type: "show" | "movie";
 }


### PR DESCRIPTION
Fixes the logic in the unreleased code to account for future releases in the same year

The check is slightly more complex than I would have liked due to bookmarks and watched history items not storing the release date