### PR TITLE
Route HLS audio tracks through extension

### DIFF
--- a/src/backend/extension/messaging.ts
+++ b/src/backend/extension/messaging.ts
@@ -9,6 +9,7 @@ import { ExtensionMakeRequestResponse } from "@/backend/extension/plasmo";
 export const RULE_IDS = {
   PREPARE_STREAM: 1,
   SET_DOMAINS_HLS: 2,
+  SET_DOMAINS_HLS_AUDIO: 3,
 };
 
 // for some reason, about 500 ms is needed after

--- a/src/components/player/display/base.ts
+++ b/src/components/player/display/base.ts
@@ -191,6 +191,21 @@ export function makeVideoElementDisplayInterface(): DisplayInterface {
                 },
               });
             });
+            hls.on(Hls.Events.AUDIO_TRACK_LOADED, async (_, data) => {
+              const chunkUrlsDomains = data.details.fragments.map(
+                (v) => new URL(v.url).hostname,
+              );
+              const chunkUrls = [...new Set(chunkUrlsDomains)];
+
+              await setDomainRule({
+                ruleId: RULE_IDS.SET_DOMAINS_HLS_AUDIO,
+                targetDomains: chunkUrls,
+                requestHeaders: {
+                  ...src.preferredHeaders,
+                  ...src.headers,
+                },
+              });
+            });
           }
         });
         hls.on(Hls.Events.LEVEL_SWITCHED, () => {


### PR DESCRIPTION
Ridomovies is currently not working for the closeload embed, because the audio tracks are not routed through the extension. These requests are responding with a 403. This PR fixes that

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
