### PR TITLE
Fixes for VidSrcTo & Ridomovies

### DIFF
--- a/src/components/player/display/base.ts
+++ b/src/components/player/display/base.ts
@@ -83,7 +83,8 @@ export function makeVideoElementDisplayInterface(): DisplayInterface {
 
   function reportAudioTracks() {
     if (!hls) return;
-    const currentTrack = hls.audioTracks[hls.audioTrack];
+    const currentTrack = hls.audioTracks?.[hls.audioTrack ?? 0];
+    if (!currentTrack) return;
     emit("changedaudiotrack", {
       id: currentTrack.id.toString(),
       label: currentTrack.name,
@@ -129,6 +130,7 @@ export function makeVideoElementDisplayInterface(): DisplayInterface {
   }
 
   function setupSource(vid: HTMLVideoElement, src: LoadableSource) {
+    hls = null;
     if (src.type === "hls") {
       if (canPlayHlsNatively(vid)) {
         vid.src = processCdnLink(src.url);


### PR DESCRIPTION
If no audio tracks were available, reportAudioTracks() would cause a crash and the events wouldn't be triggered.
When switching from an HLS source to an HLS source, the hls variable sometimes would not reset. This caused the HLS events to still have an old reference to the src object, causing it to call the extension with the old src headers.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
