### PR TITLE
Select default audio language based on setting

### DIFF
--- a/src/components/player/display/base.ts
+++ b/src/components/player/display/base.ts
@@ -12,6 +12,7 @@ import {
 } from "@/components/player/display/displayInterface";
 import { handleBuffered } from "@/components/player/utils/handleBuffered";
 import { getMediaErrorDetails } from "@/components/player/utils/mediaErrorDetails";
+import { useLanguageStore } from "@/stores/language";
 import {
   LoadableSource,
   SourceQuality,
@@ -83,7 +84,13 @@ export function makeVideoElementDisplayInterface(): DisplayInterface {
 
   function reportAudioTracks() {
     if (!hls) return;
-    const currentTrack = hls.audioTracks?.[hls.audioTrack ?? 0];
+    const currentLanguage = useLanguageStore.getState().language;
+    const audioTracks = hls.audioTracks;
+    const languageTrack = audioTracks.find((v) => v.lang === currentLanguage);
+    if (languageTrack) {
+      hls.audioTrack = audioTracks.indexOf(languageTrack);
+    }
+    const currentTrack = audioTracks?.[hls.audioTrack ?? 0];
     if (!currentTrack) return;
     emit("changedaudiotrack", {
       id: currentTrack.id.toString(),

--- a/src/stores/player/slices/source.ts
+++ b/src/stores/player/slices/source.ts
@@ -169,6 +169,8 @@ export const createSourceSlice: MakeSlice<SourceSlice> = (set, get) => ({
       s.captionList = captions;
       s.interface.error = undefined;
       s.status = playerStatus.PLAYING;
+      s.audioTracks = [];
+      s.currentAudioTrack = null;
     });
     const store = get();
     store.redisplaySource(startAt);


### PR DESCRIPTION
- It now selects the audio language based on your chosen language. This is of course not completely bulletproof, because if a provider would have the audio language set as "eng" while we have it as "en" it won't work. This was working for one source so in my opinion this is worth adding.
- Also fixed an issue where the audio tracks were not reset when you switch sources.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [ ] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
