### PR TITLE
Implement functionality to open URL in new tab on middle click

### DIFF
--- a/src/components/player/base/BackLink.tsx
+++ b/src/components/player/base/BackLink.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
@@ -7,11 +8,23 @@ export function BackLink(props: { url: string }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    // Check if center mouse button is clicked
+    if (event.button === 1) {
+      // Open the URL in a new tab
+      window.open(props.url, "_blank");
+    } else {
+      // Navigate normally for other clicks
+      navigate(props.url);
+    }
+  };
   return (
     <div className="flex items-center">
       <button
         type="button"
-        onClick={() => navigate(props.url)}
+        onContextMenu={(e) => e.preventDefault()}
+        onMouseUp={handleClick}
         className="py-1 -my-1 px-2 -mx-2 tabbable rounded-lg flex items-center cursor-pointer text-type-secondary hover:text-white transition-colors duration-200 font-medium"
       >
         <Icon className="mr-2" icon={Icons.ARROW_LEFT} />

--- a/src/components/player/base/BackLink.tsx
+++ b/src/components/player/base/BackLink.tsx
@@ -1,36 +1,21 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 import { Icon, Icons } from "@/components/Icon";
 
 export function BackLink(props: { url: string }) {
   const { t } = useTranslation();
-  const navigate = useNavigate();
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    // Check if center mouse button is clicked
-    if (event.button === 1) {
-      // Open the URL in a new tab
-      window.open(props.url, "_blank");
-    } else {
-      // Navigate normally for other clicks
-      navigate(props.url);
-    }
-  };
   return (
     <div className="flex items-center">
-      <button
-        type="button"
-        onContextMenu={(e) => e.preventDefault()}
-        onMouseUp={handleClick}
+      <Link
+        to={props.url}
         className="py-1 -my-1 px-2 -mx-2 tabbable rounded-lg flex items-center cursor-pointer text-type-secondary hover:text-white transition-colors duration-200 font-medium"
       >
         <Icon className="mr-2" icon={Icons.ARROW_LEFT} />
         <span className="md:hidden">{t("player.back.short")}</span>
         <span className="hidden md:block">{t("player.back.default")}</span>
-      </button>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
In [src/components/player/base/BackLink.tsx](https://github.com/movie-web/movie-web/blob/dev/src/components/player/base/BackLink.tsx)
- Added handleClick function to check for middle mouse button (event.button === 1), opening the URL in a new tab using window.open.
- Improves user experience by offering an alternative method to open URLs without leaving the current page.

This pull request resolves #1018 

 - [X] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [X] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [X] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [X] I have tested all of my changes.
