### PR TITLE
Use vanilla AbortController for compatability

### DIFF
--- a/src/backend/metadata/tmdb.ts
+++ b/src/backend/metadata/tmdb.ts
@@ -153,6 +153,12 @@ const tmdbHeaders = {
   Authorization: `Bearer ${apiKey}`,
 };
 
+function abortOnTimeout(timeout: number): AbortSignal {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), timeout);
+  return controller.signal;
+}
+
 async function get<T>(url: string, params?: object): Promise<T> {
   if (!apiKey) throw new Error("TMDB API key not set");
   try {
@@ -162,7 +168,7 @@ async function get<T>(url: string, params?: object): Promise<T> {
       params: {
         ...params,
       },
-      signal: AbortSignal.timeout(5000),
+      signal: abortOnTimeout(5000),
     });
   } catch (err) {
     return mwFetch<T>(encodeURI(url), {
@@ -171,7 +177,7 @@ async function get<T>(url: string, params?: object): Promise<T> {
       params: {
         ...params,
       },
-      signal: AbortSignal.timeout(30000),
+      signal: abortOnTimeout(30000),
     });
   }
 }


### PR DESCRIPTION
This pull request resolves #1120

Changes using [AbortSignal.timeout](https://caniuse.com/mdn-api_abortsignal_timeout_static) to [AbortController](https://caniuse.com/abortcontroller) for better browser support

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
