### PR TITLE
fix tmdb 404 request

### DIFF
--- a/src/components/player/atoms/NextEpisodeButton.tsx
+++ b/src/components/player/atoms/NextEpisodeButton.tsx
@@ -46,9 +46,13 @@ function Button(props: {
   );
 }
 
-function useSeasons(mediaId: string, isLastEpisode: boolean = false) {
+function useSeasons(
+  mediaId: string | undefined,
+  isLastEpisode: boolean = false,
+) {
   const state = useAsync(async () => {
     if (isLastEpisode) {
+      if (!mediaId) return;
       const data = await getMetaFromId(MWMediaType.SERIES, mediaId);
       if (data?.meta.type !== MWMediaType.SERIES) return null;
       return data.meta.seasons;
@@ -60,7 +64,7 @@ function useSeasons(mediaId: string, isLastEpisode: boolean = false) {
 
 function useNextSeasonEpisode(
   nextSeason: MWSeasonMeta | undefined,
-  mediaId: string,
+  mediaId: string | undefined,
 ) {
   const state = useAsync(async () => {
     if (nextSeason) {
@@ -111,16 +115,13 @@ export function NextEpisodeButton(props: {
       ? false
       : meta.episode.number === meta.episodes.at(-1)!.number;
 
-  const seasons = useSeasons(meta?.tmdbId ?? "", isLastEpisode);
+  const seasons = useSeasons(meta?.tmdbId, isLastEpisode);
 
   const nextSeason = seasons.value?.find(
     (season) => season.number === (meta?.season?.number ?? 0) + 1,
   );
 
-  const nextSeasonEpisode = useNextSeasonEpisode(
-    nextSeason,
-    meta?.tmdbId ?? "",
-  );
+  const nextSeasonEpisode = useNextSeasonEpisode(nextSeason, meta?.tmdbId);
 
   let show = false;
   const hasAutoplayed = useRef(false);

--- a/src/components/player/atoms/NextEpisodeButton.tsx
+++ b/src/components/player/atoms/NextEpisodeButton.tsx
@@ -49,7 +49,7 @@ function Button(props: {
 function useSeasons(mediaId: string, isLastEpisode: boolean = false) {
   const state = useAsync(async () => {
     if (isLastEpisode) {
-      const data = await getMetaFromId(MWMediaType.SERIES, mediaId ?? "");
+      const data = await getMetaFromId(MWMediaType.SERIES, mediaId);
       if (data?.meta.type !== MWMediaType.SERIES) return null;
       return data.meta.seasons;
     }
@@ -64,9 +64,10 @@ function useNextSeasonEpisode(
 ) {
   const state = useAsync(async () => {
     if (nextSeason) {
+      if (!mediaId) return;
       const data = await getMetaFromId(
         MWMediaType.SERIES,
-        mediaId ?? "",
+        mediaId,
         nextSeason?.id,
       );
       if (data?.meta.type !== MWMediaType.SERIES) return null;
@@ -106,7 +107,9 @@ export function NextEpisodeButton(props: {
   const enableAutoplay = usePreferencesStore((s) => s.enableAutoplay);
 
   const isLastEpisode =
-    meta?.episode?.number === meta?.episodes?.at(-1)?.number;
+    !meta?.episode?.number || !meta?.episodes?.at(-1)?.number
+      ? false
+      : meta.episode.number === meta.episodes.at(-1)!.number;
 
   const seasons = useSeasons(meta?.tmdbId ?? "", isLastEpisode);
 

--- a/src/components/player/atoms/NextEpisodeButton.tsx
+++ b/src/components/player/atoms/NextEpisodeButton.tsx
@@ -52,7 +52,7 @@ function useSeasons(
 ) {
   const state = useAsync(async () => {
     if (isLastEpisode) {
-      if (!mediaId) return;
+      if (!mediaId) return null;
       const data = await getMetaFromId(MWMediaType.SERIES, mediaId);
       if (data?.meta.type !== MWMediaType.SERIES) return null;
       return data.meta.seasons;
@@ -68,7 +68,7 @@ function useNextSeasonEpisode(
 ) {
   const state = useAsync(async () => {
     if (nextSeason) {
-      if (!mediaId) return;
+      if (!mediaId) return null;
       const data = await getMetaFromId(
         MWMediaType.SERIES,
         mediaId,


### PR DESCRIPTION
This pull request resolves #1118

If the episodes didnt exist (for movies), the isLastEpisode boolean resolves to true, and did a call without a mediaId. Now it does not do the call anymore, and also does no call if the mediaId is not defined.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
