### PR TITLE
Update index.ts

### DIFF
--- a/src/stores/subtitles/index.ts
+++ b/src/stores/subtitles/index.ts
@@ -55,9 +55,9 @@ export const useSubtitleStore = create(
       delay: 0,
       styling: {
         color: "#ffffff",
-        backgroundOpacity: 0.5,
+        backgroundOpacity: 0,
         size: 1,
-        backgroundBlur: 0.5,
+        backgroundBlur: 0,
       },
       resetSubtitleSpecificSettings() {
         set((s) => {


### PR DESCRIPTION
Set the default values for background blur and background opacity to 0. This eliminates any distracting effects around the subtitles, ensuring they function as intended.

This pull request resolves #1064
 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
