### PR TITLE
decrease amount of margin of edit button on small screens

### DIFF
--- a/src/components/buttons/EditButton.tsx
+++ b/src/components/buttons/EditButton.tsx
@@ -25,7 +25,7 @@ export function EditButton(props: EditButtonProps) {
     >
       <span ref={parent}>
         {props.editing ? (
-          <span className="mx-4 whitespace-nowrap">
+          <span className="mx-2 sm:mx-4 whitespace-nowrap">
             {t("home.mediaList.stopEditing")}
           </span>
         ) : (


### PR DESCRIPTION
This pull request resolves #962 
For really small screens the edit button did not have enough space on the right side. Decreased it a bit, so as long as you do not have a flip phone this should be good enough.

https://github.com/movie-web/movie-web/assets/43169049/b902d9d9-4b6c-4817-a470-8785c2ebed58

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
