### PR TITLE
Add direct bookmarking from movie thumbnails

### DIFF
--- a/src/components/buttons/IconPatch.tsx
+++ b/src/components/buttons/IconPatch.tsx
@@ -2,7 +2,7 @@ import { Icon, Icons } from "@/components/Icon";
 
 export interface IconPatchProps {
   active?: boolean;
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   clickable?: boolean;
   className?: string;
   icon: Icons;

--- a/src/components/media/MediaCard.tsx
+++ b/src/components/media/MediaCard.tsx
@@ -10,6 +10,7 @@ import { MediaItem } from "@/utils/mediaTypes";
 
 import { IconPatch } from "../buttons/IconPatch";
 import { Icons } from "../Icon";
+import { MediaCardBookmarkButton } from "../player/Player";
 
 export interface MediaCardProps {
   media: MediaItem;
@@ -22,6 +23,7 @@ export interface MediaCardProps {
   };
   percentage?: number;
   closable?: boolean;
+  shouldShowBookMark?: boolean;
   onClose?: () => void;
 }
 
@@ -45,6 +47,7 @@ function MediaCardContent({
   series,
   percentage,
   closable,
+  shouldShowBookMark = true,
   onClose,
 }: MediaCardProps) {
   const { t } = useTranslation();
@@ -153,6 +156,19 @@ function MediaCardContent({
               icon={Icons.X}
             />
           </div>
+
+          {shouldShowBookMark && (
+            <div
+              className={classNames(
+                `absolute left-2 top-2 rounded-md transition-opacity opacity-0 group-hover:opacity-100 duration-300`,
+                {
+                  "opacity-100": closable,
+                },
+              )}
+            >
+              <MediaCardBookmarkButton media={media} />
+            </div>
+          )}
         </div>
         <h1 className="mb-1 line-clamp-3 max-h-[4.5rem] text-ellipsis break-words font-bold text-white">
           <span>{media.title}</span>

--- a/src/components/media/WatchedMediaCard.tsx
+++ b/src/components/media/WatchedMediaCard.tsx
@@ -22,6 +22,7 @@ function formatSeries(series?: ShowProgressResult | null) {
 export interface WatchedMediaCardProps {
   media: MediaItem;
   closable?: boolean;
+  shouldShowBookMark?: boolean;
   onClose?: () => void;
 }
 
@@ -46,6 +47,7 @@ export function WatchedMediaCard(props: WatchedMediaCardProps) {
       percentage={percentage}
       onClose={props.onClose}
       closable={props.closable}
+      shouldShowBookMark={props.shouldShowBookMark}
     />
   );
 }

--- a/src/components/player/internals/BookmarkButton.tsx
+++ b/src/components/player/internals/BookmarkButton.tsx
@@ -1,8 +1,10 @@
 import { useCallback } from "react";
 
+import { IconPatch } from "@/components/buttons/IconPatch";
 import { Icons } from "@/components/Icon";
 import { useBookmarkStore } from "@/stores/bookmarks";
 import { usePlayerStore } from "@/stores/player/store";
+import { MediaItem } from "@/utils/mediaTypes";
 
 import { VideoPlayerButton } from "./Button";
 
@@ -25,6 +27,42 @@ export function BookmarkButton() {
       icon={isBookmarked ? Icons.BOOKMARK : Icons.BOOKMARK_OUTLINE}
       iconSizeClass="text-base"
       className="p-3"
+    />
+  );
+}
+
+export function MediaCardBookmarkButton(props: { media: MediaItem }) {
+  const addBookmark = useBookmarkStore((s) => s.addBookmark);
+  const removeBookmark = useBookmarkStore((s) => s.removeBookmark);
+  const bookmarks = useBookmarkStore((s) => s.bookmarks);
+  const isBookmarked = !!bookmarks[props.media.id];
+
+  const toggleBookmark = useCallback(
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      event.preventDefault();
+      if (!props.media.year) return;
+      if (isBookmarked) {
+        removeBookmark(props.media.id);
+      } else {
+        addBookmark({
+          tmdbId: props.media.id,
+          title: props.media.title,
+          releaseYear: props.media.year,
+          type: props.media.type,
+          poster: props.media.poster,
+        });
+      }
+    },
+    [isBookmarked, props.media, addBookmark, removeBookmark],
+  );
+
+  if (!props.media.year) return null;
+
+  return (
+    <IconPatch
+      clickable
+      onClick={toggleBookmark}
+      icon={isBookmarked ? Icons.BOOKMARK : Icons.BOOKMARK_OUTLINE}
     />
   );
 }

--- a/src/pages/parts/home/BookmarksPart.tsx
+++ b/src/pages/parts/home/BookmarksPart.tsx
@@ -58,6 +58,7 @@ export function BookmarksPart() {
             media={v}
             closable={editing}
             onClose={() => removeBookmark(v.id)}
+            shouldShowBookMark={false}
           />
         ))}
       </MediaGrid>


### PR DESCRIPTION
This pull request resolves #900 
I introduced a 'shouldShowBookmark' prop to keep the original edit flow of the bookmarks part on the home page. Otherwise the bookmark button would also show up there, which would counteract the current functionality.


https://github.com/movie-web/movie-web/assets/43169049/afda764d-2f10-4120-9a7d-f8b4a03ac374



 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
